### PR TITLE
Remove sensitive log messages

### DIFF
--- a/pkg/templates/k8sresource_funcs.go
+++ b/pkg/templates/k8sresource_funcs.go
@@ -30,15 +30,11 @@ func (t *TemplateResolver) fromSecret(namespace string, secretname string, key s
 
 		return "", err
 	}
-	glog.V(glogDefLvl).Infof("Secret is %v", secret)
-
 	keyVal := secret.Data[key]
-	glog.V(glogDefLvl).Infof("Secret Key:%v, Value: %v", key, keyVal)
 
 	// when using corev1 secret api, the data is returned decoded ,
 	// re-encododing to be able to use it in the referencing secret
 	sEnc := base64.StdEncoding.EncodeToString(keyVal)
-	glog.V(glogDefLvl).Infof("encoded secret Key:%v, Value: %v", key, sEnc)
 
 	return sEnc, nil
 }


### PR DESCRIPTION
These log messages are not enabled by default but they should not be
here due to it potentially causing sensitive data to leak.