### PR TITLE
Add automatic decryption

### DIFF
--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -5,6 +5,7 @@ package templates
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -62,6 +63,9 @@ var (
 // - AESKey is an AES key (e.g. AES-256) to use for the "protect" template function and decrypting
 // such values. If it's not specified, the "protect" template function will be undefined.
 //
+// - DecryptionConcurrency is the concurrency (i.e. number of Goroutines) limit when decrypting encrypted strings. Not
+// setting this value is the equivalent of setting this to 1, which means no concurrency.
+//
 // - DisabledFunctions is a slice of default template function names that should be disabled.
 // - KubeAPIResourceList sets the cache for the Kubernetes API resources. If this is
 // set, template processing will not try to rediscover the Kubernetes API resources
@@ -88,6 +92,7 @@ var (
 type Config struct {
 	AdditionalIndentation uint
 	AESKey                []byte
+	DecryptionConcurrency uint8
 	DisabledFunctions     []string
 	EncryptionMode        EncryptionMode
 	InitializationVector  []byte
@@ -358,28 +363,115 @@ func (t *TemplateResolver) processForAutoIndent(str string) string {
 	return processed
 }
 
-// processEncryptedStrs replaces all encrypted strings with the decrypted values.
+// processEncryptedStrs replaces all encrypted strings with the decrypted values. Each decryption is handled
+// concurrently and the concurrency limit is controlled by t.config.DecryptionConcurrency. If a decryption fails,
+// the rest of the decryption is halted and an error is returned.
 func (t *TemplateResolver) processEncryptedStrs(templateStr string) (string, error) {
 	// This catching any encrypted string in the format of $ocm_encrypted:<base64 of the encrypted value>.
 	re := regexp.MustCompile(regexp.QuoteMeta(protectedPrefix) + "([a-zA-Z0-9+/=]+)")
 	// Each submatch will have index 0 be the whole match and index 1 as the base64 of the encrypted value.
 	submatches := re.FindAllStringSubmatch(templateStr, -1)
 
-	processed := templateStr
-
-	for _, submatch := range submatches {
-		match := submatch[0]
-		encryptedValue := submatch[1]
-
-		decryptedValue, err := t.decrypt(encryptedValue)
-		if err != nil {
-			return "", fmt.Errorf("decryption of %s failed: %w", match, err)
-		}
-
-		processed = strings.Replace(processed, match, decryptedValue, 1)
+	if len(submatches) == 0 {
+		return templateStr, nil
 	}
 
+	var numWorkers int
+
+	// Determine how many Goroutines to spawn.
+	if t.config.DecryptionConcurrency <= 1 {
+		numWorkers = 1
+	} else if len(submatches) > int(t.config.DecryptionConcurrency) {
+		numWorkers = int(t.config.DecryptionConcurrency)
+	} else {
+		numWorkers = len(submatches)
+	}
+
+	submatchesChan := make(chan []string, len(submatches))
+	resultsChan := make(chan decryptResult, len(submatches))
+
+	glog.V(glogDefLvl).Infof("Will decrypt %d value(s) with %d Goroutines", len(submatches), numWorkers)
+
+	// Create a context to be able to cancel decryption in case one fails.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start up all the Goroutines.
+	for i := 0; i < numWorkers; i++ {
+		go t.decryptWrapper(ctx, submatchesChan, resultsChan)
+	}
+
+	// Send all the submatches of all the encrypted strings to the Goroutines to process.
+	for _, submatch := range submatches {
+		submatchesChan <- submatch
+	}
+
+	processed := templateStr
+	processedResults := 0
+
+	for result := range resultsChan {
+		// If an error occurs, stop the Goroutines and return the error.
+		if result.err != nil {
+			// Cancel the context so the Goroutines exit before the channels close.
+			cancel()
+			close(submatchesChan)
+			close(resultsChan)
+			glog.Errorf("Decryption failed %v", result.err)
+
+			return "", fmt.Errorf("decryption of %s failed: %w", result.match, result.err)
+		}
+
+		processed = strings.Replace(processed, result.match, result.plaintext, 1)
+		processedResults++
+
+		// Once the decryption is complete, it's safe to close the channels and stop blocking in this Goroutine.
+		if processedResults == len(submatches) {
+			close(submatchesChan)
+			close(resultsChan)
+		}
+	}
+
+	glog.V(glogDefLvl).Infof("Finished decrypting %d value(s)", len(submatches))
+
 	return processed, nil
+}
+
+// decryptResult is the result sent back on the "results" channel in decryptWrapper.
+type decryptResult struct {
+	match     string
+	plaintext string
+	err       error
+}
+
+// decryptWrapper wraps the decrypt method for concurrency. ctx is the context that will get canceled if one or more
+// decryptions fail. This will halt the Goroutine early. submatches is the channel with the incoming strings to decrypt
+// which gets closed when all the encrypted values have been decrypted. Its values are string slices with the first
+// index being the whole string that will be replaced and second index being the base64 of the encrypted string. results
+// is a channel to communicate back to the calling Goroutine.
+func (t *TemplateResolver) decryptWrapper(
+	ctx context.Context, submatches <-chan []string, results chan<- decryptResult,
+) {
+	for submatch := range submatches {
+		match := submatch[0]
+		encryptedValue := submatch[1]
+		var result decryptResult
+
+		plaintext, err := t.decrypt(encryptedValue)
+		if err != nil {
+			result = decryptResult{match, "", err}
+		} else {
+			result = decryptResult{match, plaintext, nil}
+		}
+
+		select {
+		case <-ctx.Done():
+			// Return when decryption has been canceled.
+			return
+		case results <- result:
+			// Continue on to the next submatch.
+			continue
+		}
+	}
 }
 
 // jsonToYAML converts JSON to YAML using yaml.v3. This is important since

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -312,6 +312,15 @@ func TestResolveTemplate(t *testing.T) {
 			nil,
 		},
 		{
+			"value: $ocm_encrypted:Eud/p3S7TvuP03S9fuNV+w==\n" +
+				"value2: $ocm_encrypted:rBaGZbpT4WOXZzFI+XBrgg==\n" +
+				"value3: $ocm_encrypted:rcKUPnLe4rejwXzsm2/g/w==",
+			Config{AESKey: key, DecryptionConcurrency: 5, EncryptionMode: DecryptionEnabled, InitializationVector: iv},
+			struct{}{},
+			"value: Raleigh\nvalue2: Raleigh2\nvalue3: Raleigh3",
+			nil,
+		},
+		{
 			"value: Raleigh", // No encryption string to decrypt
 			Config{AESKey: key, EncryptionMode: DecryptionEnabled, InitializationVector: iv},
 			struct{}{},


### PR DESCRIPTION
This automatically detects strings in the format of `$ocm_encrypted:<base64 of encrypted string>` and replaces them with the original plaintext.

The second commit adds concurrency for the decryption process. Having it as a separate commit allows us to easily remove it if the squad to decides against it.

Resolves:
https://github.com/stolostron/backlog/issues/18705