### PR TITLE
Add `UsesEncryption` method

### DIFF
--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -180,6 +180,34 @@ func HasTemplate(template []byte, startDelim string, checkForEncrypted bool) boo
 	return hasTemplate
 }
 
+// UsesEncryption searches for templates that would generate encrypted values and returns a boolean
+// whether one was found.
+func UsesEncryption(template []byte, startDelim string, stopDelim string) bool {
+	if startDelim == "" {
+		startDelim = defaultStartDelim
+	}
+
+	if stopDelim == "" {
+		stopDelim = defaultStopDelim
+	}
+
+	templateStr := string(template)
+	glog.V(glogDefLvl).Infof("usesEncryption template str:  %v", templateStr)
+	glog.V(glogDefLvl).Infof("Checking for encryption functions")
+
+	// Check for encryption template functions:
+	// {{ fromSecret ... }}
+	// {{ ... | protect }}
+	d1 := regexp.QuoteMeta(startDelim)
+	d2 := regexp.QuoteMeta(stopDelim)
+	re := regexp.MustCompile(d1 + `(\s*fromSecret\s+.*|.*\|\s*protect\s*)` + d2)
+	usesEncryption := re.MatchString(templateStr)
+
+	glog.V(glogDefLvl).Infof("usesEncryption: %v", usesEncryption)
+
+	return usesEncryption
+}
+
 // getValidContext takes an input context struct with string fields and
 // validates it. If is is valid, the context will be returned as is. If the
 // input context is nil, an empty struct will be returned. If it's not valid, an

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -416,7 +416,7 @@ func (t *TemplateResolver) indent(spaces int, v string) string {
 // This is so that the user gets a nicer error in the event some valid scenario slips through the
 // regex.
 func autoindent(v string) (string, error) {
-	return "", errors.New("an unexpeceted error occurred where autoindent could not be processed")
+	return "", errors.New("an unexpected error occurred where autoindent could not be processed")
 }
 
 func toInt(v interface{}) int {

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -530,6 +530,42 @@ func TestHasTemplate(t *testing.T) {
 	}
 }
 
+func TestUsesEncryption(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		input      string
+		startDelim string
+		StopDelim  string
+		result     bool
+	}{
+		{" I am a sample unencrypted template ", "{{", "}}", false},
+		{" I am a sample unencrypted template ", "", "", false},
+		{" I am a {{ sample }}  unencrypted template ", "{{", "}}", false},
+		{" I am a {{ fromSecret test-secret }}  encrypted template ", "{{", "}}", true},
+		{" I am a {{ test-secret | protect }}  encrypted template ", "{{", "}}", true},
+		{`{"msg: "I am a {{ sample }} unencrypted template"}`, "{{", "}}", false},
+		{`{"msg: "I am a {{ fromSecret test-secret }}  encrypted template"}`, "{{", "}}", true},
+		{`{"msg: "I am a {{ test-secret | protect }}  encrypted template"}`, "{{", "}}", true},
+		{" I am a {{ sample }}  unencrypted template ", "", "", false},
+		{" I am a {{ fromSecret test-secret }}  encrypted template ", "", "", true},
+		{" I am a {{ test-secret | protect }}  encrypted template ", "", "", true},
+		{" I am a {{ sample }}  unencrypted template ", "{{hub", "hub}}", false},
+		{" I am a {{ fromSecret test-secret }}  encrypted template ", "{{hub", "hub}}", false},
+		{" I am a {{ test-secret | protect }}  encrypted template ", "{{hub", "hub}}", false},
+		{" I am a {{hub sample hub}}  template ", "{{hub", "hub}}", false},
+		{" I am a {{hub fromSecret test-secret hub}}  template ", "{{hub", "hub}}", true},
+		{" I am a {{hub test-secret | protect hub}}  template ", "{{hub", "hub}}", true},
+	}
+
+	for _, test := range testcases {
+		val := UsesEncryption([]byte(test.input), test.startDelim, test.StopDelim)
+		if val != test.result {
+			t.Fatalf("'%s' expected UsesEncryption : %v , got : %v", test.input, test.result, val)
+		}
+	}
+}
+
 func TestAtoi(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Checks for the presence of `fromSecret` and/or `protect` template functions (it assumes encryption is already enabled if this check is being done).

This is for implementing the `protect` function so that we only generate secrets and initialization vectors when required:
- https://github.com/stolostron/backlog/issues/18712