### PR TITLE
Return an additional specific error for a template resolve failure

### DIFF
--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -484,6 +484,18 @@ func TestResolveTemplate(t *testing.T) {
 			"",
 			ErrMissingAPIResource,
 		},
+		{
+			`value: '{{ index (lookup "v1" "NotAResource" "namespace" "object").data.list 2 }}'`,
+			Config{KubeAPIResourceList: []*metav1.APIResourceList{}},
+			struct{}{},
+			"",
+			errors.New(
+				`one or more API resources are not installed on the API server which could have led to the ` +
+					`templating error: template: tmpl:1:11: executing "tmpl" at <index (lookup "v1" "NotAResource" ` +
+					`"namespace" "object").data.list 2>: error calling index: index of untyped nil: ` +
+					`{"value":"{{ index (lookup \"v1\" \"NotAResource\" \"namespace\" \"object\").data.list 2 }}"}`,
+			),
+		},
 	}
 
 	for _, test := range testcases {


### PR DESCRIPTION
When a template fails to resolve likely due to `KubeAPIResourceList`
being out of date, return a specific error.

This is a follow-up to d15e3d46ea197ebdb88cb108da008615651a0888.

Relates:
https://github.com/stolostron/backlog/issues/20382