### PR TITLE
Add an option to treat a JSON string as literal JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,8 @@ Additionally, the following custom functions are supported:
 - `toInt` parses an input string and returns an integer but also removes any
   quotes around the map value. For example, `key: "{{ "6" | toInt }}"` =>
   `key: 6`.
+- `toLiteral` removes any quotes around the template string after it is
+  processed. For example, `key: "{{ "[10.10.10.10, 1.1.1.1]" | toLiteral }}` =>
+  `key: [10.10.10.10, 1.1.1.1]`. A good use-case for this is when a `ConfigMap`
+  field contains a JSON string that you want to literally replace the
+  template with and have it treated as the underlying JSON type.

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -355,6 +355,7 @@ func (t *TemplateResolver) ResolveTemplate(tmplJSON []byte, context interface{})
 		"atoi":             atoi,
 		"toInt":            toInt,
 		"toBool":           toBool,
+		"toLiteral":        toLiteral,
 	}
 
 	// Add all the functions from sprig we will support
@@ -394,7 +395,9 @@ func (t *TemplateResolver) ResolveTemplate(tmplJSON []byte, context interface{})
 	}
 
 	// process for int or bool
-	if strings.Contains(templateStr, "toInt") || strings.Contains(templateStr, "toBool") {
+	if strings.Contains(templateStr, "toInt") ||
+		strings.Contains(templateStr, "toBool") ||
+		strings.Contains(templateStr, "toLiteral") {
 		templateStr = t.processForDataTypes(templateStr)
 	}
 
@@ -448,9 +451,9 @@ func (t *TemplateResolver) ResolveTemplate(tmplJSON []byte, context interface{})
 
 // nolint: wsl
 func (t *TemplateResolver) processForDataTypes(str string) string {
-	// the idea is to remove the quotes enclosing the template if it has toBool ot ToInt
-	// quotes around the resolved template forces the value to be a string..
-	// so removal of these quotes allows yaml to process the datatype correctly..
+	// The idea is to remove the quotes enclosing the template if it has toBool, toInt, or toLiteral.
+	// Quotes around the resolved template forces the value to be a string so removal of these quotes allows YAML to
+	// process the datatype correctly.
 
 	// the below pattern searches for optional block scalars | or >.. followed by the quoted template ,
 	// and replaces it with just the template txt thats inside the outer quotes
@@ -465,7 +468,7 @@ func (t *TemplateResolver) processForDataTypes(str string) string {
 	d1 := regexp.QuoteMeta(t.config.StartDelim)
 	d2 := regexp.QuoteMeta(t.config.StopDelim)
 	re := regexp.MustCompile(
-		`:\s+(?:[\|>]-?\s+)?(?:'?\s*)(` + d1 + `.*\|\s*(?:toInt|toBool).*` + d2 + `)(?:\s*'?)`,
+		`:\s+(?:[\|>]-?\s+)?(?:'?\s*)(` + d1 + `.*\|\s*(?:toInt|toBool|toLiteral).*` + d2 + `)(?:\s*'?)`,
 	)
 	glog.V(glogDefLvl).Infof("\n Pattern: %v\n", re.String())
 
@@ -573,6 +576,12 @@ func toBool(a string) bool {
 	b, _ := strconv.ParseBool(a)
 
 	return b
+}
+
+// toLiteral just returns the input string as it is, however, this template function will be used to detect when
+// to remove quotes around the template string after the template is processed.
+func toLiteral(a string) string {
+	return a
 }
 
 func (t *TemplateResolver) addToReferencedObs(apiversion string, kind string, namespace string, name string) {

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -70,8 +70,9 @@ func getTemplateResolver(c Config) *TemplateResolver {
 			Name: "testconfigmap",
 		},
 		Data: map[string]string{
-			"cmkey1": "cmkey1Val",
-			"cmkey2": "cmkey2Val",
+			"cmkey1":         "cmkey1Val",
+			"cmkey2":         "cmkey2Val",
+			"ingressSources": "[10.10.10.10, 1.1.1.1]",
 		},
 	}
 
@@ -188,6 +189,13 @@ func TestResolveTemplate(t *testing.T) {
 			Config{},
 			nil,
 			"param: cmkey1Val",
+			nil,
+		},
+		{
+			`param: '{{ fromConfigMap "testns" "testconfigmap" "ingressSources" | toLiteral }}'`,
+			Config{},
+			nil,
+			"param:\n  - 10.10.10.10\n  - 1.1.1.1",
 			nil,
 		},
 		{


### PR DESCRIPTION
This adds the toLiteral template function which simply removes the surrounding quotes around the template.

This enables a user to use a JSON string from a ConfigMap as it is.

Relates:
https://bugzilla.redhat.com/show_bug.cgi?id=2127506
https://github.com/stolostron/backlog/issues/25704

Signed-off-by: mprahl <mprahl@users.noreply.github.com>