### PR TITLE
Externalize Struct Fields;Specify  Type Metadata for Secret/ConfigMap

### DIFF
--- a/pkg/templates/clusterconfig_funcs.go
+++ b/pkg/templates/clusterconfig_funcs.go
@@ -51,7 +51,7 @@ func (t *TemplateResolver) fromClusterClaim(claimname string) (string, error) {
 	}
 
 	if _, ok := spec["value"]; ok {
-		t.addToReferencedObs(getObj.GetAPIVersion(), getObj.GetKind(), "", claimname)
+		t.addToReferencedObjects(getObj.GetAPIVersion(), getObj.GetKind(), "", claimname)
 
 		return spec["value"].(string), nil
 	}

--- a/pkg/templates/generic_lookup_func.go
+++ b/pkg/templates/generic_lookup_func.go
@@ -77,14 +77,14 @@ func (t *TemplateResolver) lookup(
 		getObj, lookupErr := dclient.Get(context.TODO(), rsrcname, metav1.GetOptions{})
 		if lookupErr == nil {
 			result = getObj.UnstructuredContent()
-			t.addToReferencedObs(getObj.GetAPIVersion(), getObj.GetKind(), ns, getObj.GetName())
+			t.addToReferencedObjects(getObj.GetAPIVersion(), getObj.GetKind(), ns, getObj.GetName())
 		}
 	} else {
 		listObj, lookupErr := dclient.List(context.TODO(), metav1.ListOptions{})
 		if lookupErr == nil {
 			result = listObj.UnstructuredContent()
 			for _, item := range listObj.Items {
-				t.addToReferencedObs(item.GetAPIVersion(), item.GetKind(), ns, item.GetName())
+				t.addToReferencedObjects(item.GetAPIVersion(), item.GetKind(), ns, item.GetName())
 			}
 		}
 	}

--- a/pkg/templates/k8sresource_funcs.go
+++ b/pkg/templates/k8sresource_funcs.go
@@ -38,7 +38,7 @@ func (t *TemplateResolver) fromSecret(namespace string, secretname string, key s
 	sEnc := base64.StdEncoding.EncodeToString(keyVal)
 
 	// add this Secret to list of  Objs referenced by the template
-	t.addToReferencedObs(secret.APIVersion, secret.Kind, secret.Namespace, secret.Name)
+	t.addToReferencedObs("/v1", "Secret", secret.Namespace, secret.Name)
 
 	return sEnc, nil
 }
@@ -78,7 +78,7 @@ func (t *TemplateResolver) fromConfigMap(namespace string, cmapname string, key 
 	glog.V(glogDefLvl).Infof("Configmap Key:%v, Value: %v", key, keyVal)
 
 	// add this Configmap to list of  Objs referenced by the template
-	t.addToReferencedObs(configmap.APIVersion, configmap.Kind, namespace, cmapname)
+	t.addToReferencedObs("/v1", "ConfigMap", namespace, cmapname)
 
 	return keyVal, nil
 }

--- a/pkg/templates/k8sresource_funcs.go
+++ b/pkg/templates/k8sresource_funcs.go
@@ -38,7 +38,7 @@ func (t *TemplateResolver) fromSecret(namespace string, secretname string, key s
 	sEnc := base64.StdEncoding.EncodeToString(keyVal)
 
 	// add this Secret to list of  Objs referenced by the template
-	t.addToReferencedObs("/v1", "Secret", secret.Namespace, secret.Name)
+	t.addToReferencedObjects("/v1", "Secret", secret.Namespace, secret.Name)
 
 	return sEnc, nil
 }
@@ -78,7 +78,7 @@ func (t *TemplateResolver) fromConfigMap(namespace string, cmapname string, key 
 	glog.V(glogDefLvl).Infof("Configmap Key:%v, Value: %v", key, keyVal)
 
 	// add this Configmap to list of  Objs referenced by the template
-	t.addToReferencedObs("/v1", "ConfigMap", namespace, cmapname)
+	t.addToReferencedObjects("/v1", "ConfigMap", namespace, cmapname)
 
 	return keyVal, nil
 }

--- a/pkg/templates/sprig_wrapper_test.go
+++ b/pkg/templates/sprig_wrapper_test.go
@@ -157,7 +157,7 @@ data:
 			panic(err)
 		}
 
-		policyResolvedJSON := resolvedResult.resolvedJSON
+		policyResolvedJSON := resolvedResult.ResolvedJSON
 		var policyResolved interface{}
 		err = yaml.Unmarshal(policyResolvedJSON, &policyResolved)
 

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -130,8 +130,8 @@ type TemplateResolver struct {
 }
 
 type TemplateResult struct {
-	resolvedJSON   []byte
-	referencedObjs []client.ObjectIdentifier
+	ResolvedJSON   []byte
+	ReferencedObjs []client.ObjectIdentifier
 }
 
 // NewResolver creates a new TemplateResolver instance, which is the API for processing templates.
@@ -440,8 +440,8 @@ func (t *TemplateResolver) ResolveTemplate(tmplJSON []byte, context interface{})
 		return resolvedResult, ErrMissingAPIResource
 	}
 
-	resolvedResult.resolvedJSON = resolvedTemplateBytes
-	resolvedResult.referencedObjs = t.referencedObjs
+	resolvedResult.ResolvedJSON = resolvedTemplateBytes
+	resolvedResult.ReferencedObjs = t.referencedObjs
 
 	return resolvedResult, nil
 }

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -126,12 +126,12 @@ type TemplateResolver struct {
 	// Denotes if the lookup template function encountered an API resource that is not installed on
 	// the Kubernetes API server.
 	missingAPIResource bool
-	referencedObjs     []client.ObjectIdentifier
+	referencedObjects  []client.ObjectIdentifier
 }
 
 type TemplateResult struct {
-	ResolvedJSON   []byte
-	ReferencedObjs []client.ObjectIdentifier
+	ResolvedJSON      []byte
+	ReferencedObjects []client.ObjectIdentifier
 }
 
 // NewResolver creates a new TemplateResolver instance, which is the API for processing templates.
@@ -333,7 +333,7 @@ func (t *TemplateResolver) ResolveTemplate(tmplJSON []byte, context interface{})
 
 	// Always reset this value on each ResolveTemplate call.
 	t.missingAPIResource = false
-	t.referencedObjs = []client.ObjectIdentifier{}
+	t.referencedObjects = []client.ObjectIdentifier{}
 
 	var resolvedResult TemplateResult
 
@@ -441,7 +441,7 @@ func (t *TemplateResolver) ResolveTemplate(tmplJSON []byte, context interface{})
 	}
 
 	resolvedResult.ResolvedJSON = resolvedTemplateBytes
-	resolvedResult.ReferencedObjs = t.referencedObjs
+	resolvedResult.ReferencedObjects = t.referencedObjects
 
 	return resolvedResult, nil
 }
@@ -575,7 +575,7 @@ func toBool(a string) bool {
 	return b
 }
 
-func (t *TemplateResolver) addToReferencedObs(apiversion string, kind string, namespace string, name string) {
+func (t *TemplateResolver) addToReferencedObjects(apiversion string, kind string, namespace string, name string) {
 	gvk := schema.FromAPIVersionAndKind(apiversion, kind)
 
 	objID := client.ObjectIdentifier{
@@ -585,5 +585,5 @@ func (t *TemplateResolver) addToReferencedObs(apiversion string, kind string, na
 		Namespace: namespace,
 		Name:      name,
 	}
-	t.referencedObjs = append(t.referencedObjs, objID)
+	t.referencedObjects = append(t.referencedObjects, objID)
 }

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -526,7 +526,7 @@ func TestResolveTemplate(t *testing.T) {
 				t.Fatalf("expected err: %s got err: %s", test.expectedErr, err)
 			}
 		} else {
-			val, err := jsonToYAML(tmplResult.resolvedJSON)
+			val, err := jsonToYAML(tmplResult.ResolvedJSON)
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
@@ -618,7 +618,7 @@ param: '{{ fromConfigMap "testns" "testconfigmap" "cmkey1"  }}'`,
 		if err != nil {
 			t.Fatalf(err.Error())
 		} else {
-			referencedObjs := tmplResult.referencedObjs
+			referencedObjs := tmplResult.ReferencedObjs
 
 			if len(referencedObjs) != len(test.expectedRefObjs) ||
 				((len(referencedObjs) != 0) && !reflect.DeepEqual(referencedObjs, test.expectedRefObjs)) {
@@ -900,7 +900,7 @@ spec:
 	templateContext := struct{ ClusterName string }{ClusterName: "cluster0001"}
 
 	tmplResult, err := resolver.ResolveTemplate(policyJSON, templateContext)
-	policyResolvedJSON := tmplResult.resolvedJSON
+	policyResolvedJSON := tmplResult.ResolvedJSON
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to process the policy YAML: %v\n", err)

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -539,7 +539,7 @@ func TestResolveTemplate(t *testing.T) {
 	}
 }
 
-func TestReferencedObjs(t *testing.T) {
+func TestReferencedObjects(t *testing.T) {
 	t.Parallel()
 
 	testcases := []struct {
@@ -618,7 +618,7 @@ param: '{{ fromConfigMap "testns" "testconfigmap" "cmkey1"  }}'`,
 		if err != nil {
 			t.Fatalf(err.Error())
 		} else {
-			referencedObjs := tmplResult.ReferencedObjs
+			referencedObjs := tmplResult.ReferencedObjects
 
 			if len(referencedObjs) != len(test.expectedRefObjs) ||
 				((len(referencedObjs) != 0) && !reflect.DeepEqual(referencedObjs, test.expectedRefObjs)) {


### PR DESCRIPTION
Signed-off-by: Chaitanya Kandagatla <ckandaga@redhat.com>

For Isssue https://github.com/stolostron/backlog/issues/25848


Struct Fields need to be capitalized in order to access them outside the templates pkg.

Also , when using Client-go /client-set, it appears the Type Metadata  in the objects returned is not set,
hardcoding the version and Kind  in fromConfigMap and fromSecret.  as the values in 
  
Dynamic client does not have this issue.
