### PR TITLE
Migrate from glog to klog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.19
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/golang/glog v1.0.0
 	github.com/spf13/cast v1.5.0
 	github.com/stolostron/kubernetes-dependency-watches v0.0.0-20221007134235-7551d84cf688
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.23.9
 	k8s.io/apimachinery v0.23.9
 	k8s.io/client-go v0.23.9
+	k8s.io/klog v1.0.0
 )
 
 require (
@@ -45,7 +45,6 @@ require (
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/klog v1.0.0 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,6 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
-github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/templates/clusterconfig_funcs.go
+++ b/pkg/templates/clusterconfig_funcs.go
@@ -8,8 +8,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/golang/glog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 )
 
 // retrieve the Spec value for the given clusterclaim.
@@ -36,7 +36,7 @@ func (t *TemplateResolver) fromClusterClaim(claimname string) (string, error) {
 
 	getObj, getErr := dclient.Get(context.TODO(), claimname, metav1.GetOptions{})
 	if getErr != nil {
-		glog.Errorf("Error retrieving clusterclaim : %v, %v", claimname, getErr)
+		klog.Errorf("Error retrieving clusterclaim : %v, %v", claimname, getErr)
 
 		return "", fmt.Errorf("failed to retrieve the cluster claim %s: %w", claimname, getErr)
 	}
@@ -45,7 +45,7 @@ func (t *TemplateResolver) fromClusterClaim(claimname string) (string, error) {
 
 	spec, ok := result["spec"].(map[string]interface{})
 	if !ok {
-		glog.Errorf("The clusterclaim %s has an unexpected format", claimname)
+		klog.Errorf("The clusterclaim %s has an unexpected format", claimname)
 
 		return "", fmt.Errorf("unexpected cluster claim format: %s", claimname)
 	}

--- a/pkg/templates/encryption.go
+++ b/pkg/templates/encryption.go
@@ -13,7 +13,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 )
 
 // protect encrypts the input value using AES-CBC. If a salt is set on t.config.Salt, it will prefix the plaintext
@@ -177,7 +177,7 @@ func (t *TemplateResolver) processEncryptedStrs(templateStr string) (string, err
 	submatchesChan := make(chan []string, len(submatches))
 	resultsChan := make(chan decryptResult, len(submatches))
 
-	glog.V(glogDefLvl).Infof("Will decrypt %d value(s) with %d Goroutines", len(submatches), numWorkers)
+	klog.V(2).Infof("Will decrypt %d value(s) with %d Goroutines", len(submatches), numWorkers)
 
 	// Create a context to be able to cancel decryption in case one fails.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -203,7 +203,7 @@ func (t *TemplateResolver) processEncryptedStrs(templateStr string) (string, err
 			cancel()
 			close(submatchesChan)
 			close(resultsChan)
-			glog.Errorf("Decryption failed %v", result.err)
+			klog.Errorf("Decryption failed %v", result.err)
 
 			return "", fmt.Errorf("decryption of %s failed: %w", result.match, result.err)
 		}
@@ -218,7 +218,7 @@ func (t *TemplateResolver) processEncryptedStrs(templateStr string) (string, err
 		}
 	}
 
-	glog.V(glogDefLvl).Infof("Finished decrypting %d value(s)", len(submatches))
+	klog.V(2).Infof("Finished decrypting %d value(s)", len(submatches))
 
 	return processed, nil
 }

--- a/pkg/templates/k8sresource_funcs.go
+++ b/pkg/templates/k8sresource_funcs.go
@@ -8,13 +8,13 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/golang/glog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 )
 
 // retrieves the value of the key in the given Secret, namespace.
 func (t *TemplateResolver) fromSecret(namespace string, secretname string, key string) (string, error) {
-	glog.V(glogDefLvl).Infof("fromSecret for namespace: %v, secretname: %v, key:%v", namespace, secretname, key)
+	klog.V(2).Infof("fromSecret for namespace: %v, secretname: %v, key:%v", namespace, secretname, key)
 
 	ns, err := t.getNamespace("fromSecret", namespace)
 	if err != nil {
@@ -25,7 +25,7 @@ func (t *TemplateResolver) fromSecret(namespace string, secretname string, key s
 	secret, getErr := secretsClient.Get(context.TODO(), secretname, metav1.GetOptions{})
 
 	if getErr != nil {
-		glog.Errorf("Error Getting secret:  %v", getErr)
+		klog.Errorf("Error Getting secret:  %v", getErr)
 		err := fmt.Errorf("failed to get the secret %s from %s: %w", secretname, ns, getErr)
 
 		return "", err
@@ -55,7 +55,7 @@ func (t *TemplateResolver) fromSecretProtected(namespace string, secretName stri
 
 // retrieves value for the key in the given Configmap, namespace.
 func (t *TemplateResolver) fromConfigMap(namespace string, cmapname string, key string) (string, error) {
-	glog.V(glogDefLvl).Infof("fromConfigMap for namespace: %v, configmap name: %v, key:%v", namespace, cmapname, key)
+	klog.V(2).Infof("fromConfigMap for namespace: %v, configmap name: %v, key:%v", namespace, cmapname, key)
 
 	ns, err := t.getNamespace("fromConfigMap", namespace)
 	if err != nil {
@@ -66,16 +66,16 @@ func (t *TemplateResolver) fromConfigMap(namespace string, cmapname string, key 
 	configmap, getErr := configmapsClient.Get(context.TODO(), cmapname, metav1.GetOptions{})
 
 	if getErr != nil {
-		glog.Errorf("Error getting configmap:  %v", getErr)
+		klog.Errorf("Error getting configmap:  %v", getErr)
 		err := fmt.Errorf("failed getting the ConfigMap %s from %s: %w", cmapname, ns, getErr)
 
 		return "", err
 	}
 
-	glog.V(glogDefLvl).Infof("Configmap is %v", configmap)
+	klog.V(2).Infof("Configmap is %v", configmap)
 
 	keyVal := configmap.Data[key]
-	glog.V(glogDefLvl).Infof("Configmap Key:%v, Value: %v", key, keyVal)
+	klog.V(2).Infof("Configmap Key:%v, Value: %v", key, keyVal)
 
 	// add this Configmap to list of  Objs referenced by the template
 	t.addToReferencedObjects("/v1", "ConfigMap", namespace, cmapname)

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cast"
 	"github.com/stolostron/kubernetes-dependency-watches/client"
 	yaml "gopkg.in/yaml.v3"
@@ -23,13 +22,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog"
 )
 
 const (
 	defaultStartDelim = "{{"
 	defaultStopDelim  = "}}"
 	IVSize            = 16 // Size in bytes
-	glogDefLvl        = 2
 	protectedPrefix   = "$ocm_encrypted:"
 	yamlIndentation   = 2
 )
@@ -159,7 +158,7 @@ func NewResolver(kubeClient *kubernetes.Interface, kubeConfig *rest.Config, conf
 		config.StopDelim = defaultStopDelim
 	}
 
-	glog.V(glogDefLvl).Infof("Using the delimiters of %s and %s", config.StartDelim, config.StopDelim)
+	klog.V(2).Infof("Using the delimiters of %s and %s", config.StartDelim, config.StopDelim)
 
 	return &TemplateResolver{
 		kubeClient: kubeClient,
@@ -177,8 +176,8 @@ func HasTemplate(template []byte, startDelim string, checkForEncrypted bool) boo
 	}
 
 	templateStr := string(template)
-	glog.V(glogDefLvl).Infof("HasTemplate template str:  %v", templateStr)
-	glog.V(glogDefLvl).Infof("Checking for the start delimiter:  %s", startDelim)
+	klog.V(2).Infof("HasTemplate template str:  %v", templateStr)
+	klog.V(2).Infof("Checking for the start delimiter:  %s", startDelim)
 
 	hasTemplate := false
 	if strings.Contains(templateStr, startDelim) {
@@ -187,7 +186,7 @@ func HasTemplate(template []byte, startDelim string, checkForEncrypted bool) boo
 		hasTemplate = true
 	}
 
-	glog.V(glogDefLvl).Infof("hasTemplate: %v", hasTemplate)
+	klog.V(2).Infof("hasTemplate: %v", hasTemplate)
 
 	return hasTemplate
 }
@@ -204,8 +203,8 @@ func UsesEncryption(template []byte, startDelim string, stopDelim string) bool {
 	}
 
 	templateStr := string(template)
-	glog.V(glogDefLvl).Infof("usesEncryption template str:  %v", templateStr)
-	glog.V(glogDefLvl).Infof("Checking for encryption functions")
+	klog.V(2).Infof("usesEncryption template str:  %v", templateStr)
+	klog.V(2).Infof("Checking for encryption functions")
 
 	// Check for encryption template functions:
 	// {{ fromSecret ... }}
@@ -215,7 +214,7 @@ func UsesEncryption(template []byte, startDelim string, stopDelim string) bool {
 	re := regexp.MustCompile(d1 + `(\s*fromSecret\s+.*|.*\|\s*protect\s*)` + d2)
 	usesEncryption := re.MatchString(templateStr)
 
-	glog.V(glogDefLvl).Infof("usesEncryption: %v", usesEncryption)
+	klog.V(2).Infof("usesEncryption: %v", usesEncryption)
 
 	return usesEncryption
 }
@@ -259,7 +258,7 @@ func (t *TemplateResolver) SetKubeAPIResourceList(resourceList []*metav1.APIReso
 // validation passes, SetEncryptionConfig updates the EncryptionConfig in the TemplateResolver
 // configuration. Otherwise, an error is returned and the configuration is unchanged.
 func (t *TemplateResolver) SetEncryptionConfig(encryptionConfig EncryptionConfig) error {
-	glog.V(glogDefLvl).Info("Setting EncryptionConfig for templates")
+	klog.V(2).Info("Setting EncryptionConfig for templates")
 
 	err := validateEncryptionConfig(encryptionConfig)
 	if err != nil {
@@ -304,14 +303,14 @@ func validateEncryptionConfig(encryptionConfig EncryptionConfig) error {
 		}
 
 		if encryptionConfig.EncryptionEnabled {
-			glog.V(glogDefLvl).Info("Template encryption is enabled")
+			klog.V(2).Info("Template encryption is enabled")
 		}
 
 		if encryptionConfig.DecryptionEnabled {
-			glog.V(glogDefLvl).Info("Template decryption is enabled")
+			klog.V(2).Info("Template decryption is enabled")
 		}
 	} else {
-		glog.V(glogDefLvl).Info("Template encryption and decryption is disabled")
+		klog.V(2).Info("Template encryption and decryption is disabled")
 	}
 
 	return nil
@@ -329,7 +328,7 @@ func validateEncryptionConfig(encryptionConfig EncryptionConfig) error {
 // returned. ErrMissingAPIResourceInvalidTemplate can also be returned in this case but it also means the template
 // failed to resolve, so the resolved template will not be returned.
 func (t *TemplateResolver) ResolveTemplate(tmplJSON []byte, context interface{}) (TemplateResult, error) {
-	glog.V(glogDefLvl).Infof("ResolveTemplate for: %v", tmplJSON)
+	klog.V(2).Infof("ResolveTemplate for: %v", string(tmplJSON))
 
 	// Always reset this value on each ResolveTemplate call.
 	t.missingAPIResource = false
@@ -385,7 +384,7 @@ func (t *TemplateResolver) ResolveTemplate(tmplJSON []byte, context interface{})
 	}
 
 	templateStr := string(templateYAMLBytes)
-	glog.V(glogDefLvl).Infof("Initial template str to resolve : %v ", templateStr)
+	klog.V(2).Infof("Initial template str to resolve : %v ", templateStr)
 
 	if t.config.DecryptionEnabled {
 		templateStr, err = t.processEncryptedStrs(templateStr)
@@ -409,7 +408,7 @@ func (t *TemplateResolver) ResolveTemplate(tmplJSON []byte, context interface{})
 	tmpl, err = tmpl.Parse(templateStr)
 	if err != nil {
 		tmplJSONStr := string(tmplJSON)
-		glog.Errorf(
+		klog.Errorf(
 			"error parsing template JSON string %v,\n template str %v,\n error: %v", tmplJSONStr, templateStr, err,
 		)
 
@@ -424,7 +423,7 @@ func (t *TemplateResolver) ResolveTemplate(tmplJSON []byte, context interface{})
 
 	if err != nil {
 		tmplJSONStr := string(tmplJSON)
-		glog.Errorf("error resolving the template %v,\n template str %v,\n error: %v", tmplJSONStr, templateStr, err)
+		klog.Errorf("error resolving the template %v,\n template str %v,\n error: %v", tmplJSONStr, templateStr, err)
 
 		if t.missingAPIResource {
 			return resolvedResult, fmt.Errorf("%w: %v: %v", ErrMissingAPIResourceInvalidTemplate, err, tmplJSONStr)
@@ -434,7 +433,7 @@ func (t *TemplateResolver) ResolveTemplate(tmplJSON []byte, context interface{})
 	}
 
 	resolvedTemplateStr := buf.String()
-	glog.V(glogDefLvl).Infof("resolved template str: %v ", resolvedTemplateStr)
+	klog.V(3).Infof("resolved template str: %v ", resolvedTemplateStr)
 	// unmarshall before returning
 
 	resolvedTemplateBytes, err := yamlToJSON([]byte(resolvedTemplateStr))
@@ -472,13 +471,13 @@ func (t *TemplateResolver) processForDataTypes(str string) string {
 	re := regexp.MustCompile(
 		`:\s+(?:[\|>]-?\s+)?(?:'?\s*)(` + d1 + `.*\|\s*(?:toInt|toBool|toLiteral).*` + d2 + `)(?:\s*'?)`,
 	)
-	glog.V(glogDefLvl).Infof("\n Pattern: %v\n", re.String())
+	klog.V(2).Infof("\n Pattern: %v\n", re.String())
 
 	submatchall := re.FindAllStringSubmatch(str, -1)
-	glog.V(glogDefLvl).Infof("\n All Submatches:\n%v", submatchall)
+	klog.V(2).Infof("\n All Submatches:\n%v", submatchall)
 
 	processeddata := re.ReplaceAllString(str, ": $1")
-	glog.V(glogDefLvl).Infof("\n processed data :\n%v", processeddata)
+	klog.V(2).Infof("\n processed data :\n%v", processeddata)
 
 	return processeddata
 }
@@ -494,12 +493,12 @@ func (t *TemplateResolver) processForAutoIndent(str string) string {
 	// `config: '{{ "hello\nworld" | autoindent }}'`. In that event, `autoindent` will change to
 	// `indent 1`, but `indent` properly handles this.
 	re := regexp.MustCompile(`( *)(?:'|")?(` + d1 + `.*\| *autoindent *` + d2 + `)`)
-	glog.V(glogDefLvl).Infof("\n Pattern: %v\n", re.String())
+	klog.V(2).Infof("\n Pattern: %v\n", re.String())
 
 	submatches := re.FindAllStringSubmatch(str, -1)
 	processed := str
 
-	glog.V(glogDefLvl).Infof("\n All Submatches:\n%v", submatches)
+	klog.V(2).Infof("\n All Submatches:\n%v", submatches)
 
 	for _, submatch := range submatches {
 		numSpaces := len(submatch[1]) - int(t.config.AdditionalIndentation)
@@ -508,7 +507,7 @@ func (t *TemplateResolver) processForAutoIndent(str string) string {
 		processed = strings.Replace(processed, matchStr, newMatchStr, 1)
 	}
 
-	glog.V(glogDefLvl).Infof("\n processed data :\n%v", processed)
+	klog.V(2).Infof("\n processed data :\n%v", processed)
 
 	return processed
 }


### PR DESCRIPTION
klog is a drop-in replacement of glog and is more compatible with container deployments and the rest of the Open Cluster Management Policy stack.

This also removes the default log level constant since that really should be a level 0 log and each log message should have a level explicitly chosen.