### PR TITLE
Disallow new lines passed to toLiteral

### DIFF
--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -45,7 +45,8 @@ var (
 	ErrMissingAPIResourceInvalidTemplate = errors.New(
 		"one or more API resources are not installed on the API server which could have led to the templating error",
 	)
-	ErrProtectNotEnabled = errors.New("the protect template function is not enabled in this mode")
+	ErrProtectNotEnabled  = errors.New("the protect template function is not enabled in this mode")
+	ErrNewLinesNotAllowed = errors.New("new lines are not allowed in the string passed to the toLiteral function")
 )
 
 // Config is a struct containing configuration for the API. Some are required.
@@ -582,8 +583,12 @@ func toBool(a string) bool {
 
 // toLiteral just returns the input string as it is, however, this template function will be used to detect when
 // to remove quotes around the template string after the template is processed.
-func toLiteral(a string) string {
-	return a
+func toLiteral(a string) (string, error) {
+	if strings.Contains(a, "\n") {
+		return "", ErrNewLinesNotAllowed
+	}
+
+	return a, nil
 }
 
 func (t *TemplateResolver) addToReferencedObjects(apiversion string, kind string, namespace string, name string) {

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -199,6 +199,13 @@ func TestResolveTemplate(t *testing.T) {
 			nil,
 		},
 		{
+			`param: '{{ "something\n  with\n  new\n lines\n" | toLiteral }}'`,
+			Config{},
+			nil,
+			"",
+			ErrNewLinesNotAllowed,
+		},
+		{
 			`config1: '{{ "testdata" | base64enc  }}'`,
 			Config{},
 			nil,
@@ -530,7 +537,7 @@ func TestResolveTemplate(t *testing.T) {
 				t.Fatalf(err.Error())
 			}
 
-			if !strings.EqualFold(test.expectedErr.Error(), err.Error()) {
+			if !(errors.Is(err, test.expectedErr) || strings.EqualFold(test.expectedErr.Error(), err.Error())) {
 				t.Fatalf("expected err: %s got err: %s", test.expectedErr, err)
 			}
 		} else {


### PR DESCRIPTION
This prevents unexpected alterations in the YAML structure prior to the current indentation level.

Relates:
https://github.com/stolostron/backlog/issues/25704