### PR TITLE
Bump the module version to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stolostron/go-template-utils/v2
+module github.com/stolostron/go-template-utils/v3
 
 go 1.19
 


### PR DESCRIPTION
This is due to the breaking change in:
https://github.com/stolostron/go-template-utils/commit/f20c2295d55ff5e4e29b0ec623a847334400c1c3

Signed-off-by: mprahl <mprahl@users.noreply.github.com>