### PR TITLE
Return object references when the object does not exist

### DIFF
--- a/pkg/templates/templates_suite_test.go
+++ b/pkg/templates/templates_suite_test.go
@@ -43,6 +43,8 @@ func testMain(m *testing.M) int {
 }
 
 func setUp() {
+	ctx, cancel = context.WithCancel(context.TODO())
+
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{"../../test_data/crds/clusterclaim.yaml"},
 	}
@@ -58,8 +60,6 @@ func setUp() {
 	if err != nil {
 		panic(err.Error())
 	}
-
-	ctx, cancel = context.WithCancel(context.TODO())
 
 	// SetUp test resources
 

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -291,6 +291,13 @@ func TestResolveTemplate(t *testing.T) {
 			nil,
 		},
 		{
+			`value: '{{ fromClusterClaim "env" }}'`,
+			Config{},
+			struct{}{},
+			"value: dev",
+			nil,
+		},
+		{
 			"value: $ocm_encrypted:Eud/p3S7TvuP03S9fuNV+w==\n" +
 				"value2: $ocm_encrypted:rBaGZbpT4WOXZzFI+XBrgg==\n" +
 				"value3: $ocm_encrypted:rcKUPnLe4rejwXzsm2/g/w==",
@@ -511,6 +518,21 @@ func TestReferencedObjects(t *testing.T) {
 			},
 		},
 		{
+			`data: '{{ fromSecret "testns" "does-not-exist" "secretkey1" }}'`,
+			Config{},
+			nil,
+			true,
+			[]client.ObjectIdentifier{
+				{
+					Group:     "",
+					Version:   "v1",
+					Kind:      "Secret",
+					Namespace: testNs,
+					Name:      "does-not-exist",
+				},
+			},
+		},
+		{
 			`param: '{{ fromConfigMap "testns" "testconfigmap" "cmkey1"  }}'`,
 			Config{},
 			nil,
@@ -568,6 +590,43 @@ func TestReferencedObjects(t *testing.T) {
 					Kind:      "ConfigMap",
 					Namespace: testNs,
 					Name:      "testconfigmap",
+				},
+				{
+					Group:     "",
+					Version:   "v1",
+					Kind:      "ConfigMap",
+					Namespace: testNs,
+					Name:      "does-not-exist",
+				},
+			},
+		},
+		{
+			`value: '{{ fromClusterClaim "env" }}'`,
+			Config{},
+			nil,
+			false,
+			[]client.ObjectIdentifier{
+				{
+					Group:     "cluster.open-cluster-management.io",
+					Version:   "v1alpha1",
+					Kind:      "ClusterClaim",
+					Namespace: "",
+					Name:      "env",
+				},
+			},
+		},
+		{
+			`data: '{{ fromClusterClaim "does-not-exist" }}'`,
+			Config{},
+			nil,
+			true,
+			[]client.ObjectIdentifier{
+				{
+					Group:     "cluster.open-cluster-management.io",
+					Version:   "v1alpha1",
+					Kind:      "ClusterClaim",
+					Namespace: "",
+					Name:      "does-not-exist",
 				},
 			},
 		},

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -497,15 +497,11 @@ func TestReferencedObjects(t *testing.T) {
 
 	testcases := []struct {
 		inputTmpl       string
-		config          Config
-		ctx             interface{}
 		errExpected     bool
 		expectedRefObjs []client.ObjectIdentifier
 	}{
 		{
 			`data: '{{ fromSecret "testns" "testsecret" "secretkey1" }}'`,
-			Config{},
-			nil,
 			false,
 			[]client.ObjectIdentifier{
 				{
@@ -519,8 +515,6 @@ func TestReferencedObjects(t *testing.T) {
 		},
 		{
 			`data: '{{ fromSecret "testns" "does-not-exist" "secretkey1" }}'`,
-			Config{},
-			nil,
 			true,
 			[]client.ObjectIdentifier{
 				{
@@ -534,8 +528,6 @@ func TestReferencedObjects(t *testing.T) {
 		},
 		{
 			`param: '{{ fromConfigMap "testns" "testconfigmap" "cmkey1"  }}'`,
-			Config{},
-			nil,
 			false,
 			[]client.ObjectIdentifier{
 				{
@@ -550,8 +542,6 @@ func TestReferencedObjects(t *testing.T) {
 		{
 			`data: '{{ fromSecret "testns" "testsecret" "secretkey1" }}'` + "\n" +
 				`param: '{{ fromConfigMap "testns" "testconfigmap" "cmkey1"  }}'`,
-			Config{},
-			nil,
 			false,
 			[]client.ObjectIdentifier{
 				{
@@ -572,16 +562,12 @@ func TestReferencedObjects(t *testing.T) {
 		},
 		{
 			`config1: '{{ "testdata" | base64enc  }}'`,
-			Config{},
-			nil,
 			false,
 			[]client.ObjectIdentifier{},
 		},
 		{
 			`data: '{{ fromConfigMap "testns" "testconfigmap" "cmkey1"  }}'` + "\n" +
 				`otherdata: '{{ fromConfigMap "testns" "does-not-exist" "cmkey23" }}'`,
-			Config{},
-			nil,
 			true,
 			[]client.ObjectIdentifier{
 				{
@@ -602,8 +588,6 @@ func TestReferencedObjects(t *testing.T) {
 		},
 		{
 			`value: '{{ fromClusterClaim "env" }}'`,
-			Config{},
-			nil,
 			false,
 			[]client.ObjectIdentifier{
 				{
@@ -617,8 +601,6 @@ func TestReferencedObjects(t *testing.T) {
 		},
 		{
 			`data: '{{ fromClusterClaim "does-not-exist" }}'`,
-			Config{},
-			nil,
 			true,
 			[]client.ObjectIdentifier{
 				{
@@ -638,12 +620,12 @@ func TestReferencedObjects(t *testing.T) {
 			t.Fatalf(err.Error())
 		}
 
-		resolver, err := NewResolver(&k8sClient, k8sConfig, test.config)
+		resolver, err := NewResolver(&k8sClient, k8sConfig, Config{})
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
 
-		tmplResult, err := resolver.ResolveTemplate(tmplStr, test.ctx)
+		tmplResult, err := resolver.ResolveTemplate(tmplStr, nil)
 		if err != nil {
 			if !test.errExpected {
 				t.Fatalf(err.Error())

--- a/test_data/crds/clusterclaim.yaml
+++ b/test_data/crds/clusterclaim.yaml
@@ -1,0 +1,38 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterclaims.cluster.open-cluster-management.io
+spec:
+  group: cluster.open-cluster-management.io
+  names:
+    kind: ClusterClaim
+    listKind: ClusterClaimList
+    plural: clusterclaims
+    singular: clusterclaim
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterClaim represents cluster information that a managed cluster claims ClusterClaims with well known names include,   1. id.k8s.io, it contains a unique identifier for the cluster.   2. clusterset.k8s.io, it contains an identifier that relates the cluster      to the ClusterSet in which it belongs.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the attributes of the ClusterClaim.
+            properties:
+              value:
+                description: Value is a claim-dependent string
+                maxLength: 1024
+                minLength: 1
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
This allows consumers to watch for objects that don't yet exist and
reexecute the templates when they do.

The second commit simplifies the `TestReferencedObjects` parameters.

Relates:
https://issues.redhat.com/browse/ACM-1936