### PR TITLE
Create functions to copy the data in configmap and secrets

### DIFF
--- a/pkg/templates/k8sresource_funcs.go
+++ b/pkg/templates/k8sresource_funcs.go
@@ -6,6 +6,7 @@ package templates
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -60,6 +61,85 @@ func (t *TemplateResolver) fromSecretProtected(namespace string, secretName stri
 	return t.protect(value)
 }
 
+// copies all data in the given Secret, namespace.
+func (t *TemplateResolver) copySecretDataBase(namespace string, secretname string) (map[string]interface{}, error) {
+	klog.V(2).Infof("copySecretDataBase for namespace: %v, secretname: %v", namespace, secretname)
+
+	ns, err := t.getNamespace("copySecretData", namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	secretsClient := (*t.kubeClient).CoreV1().Secrets(ns)
+	secret, getErr := secretsClient.Get(context.TODO(), secretname, metav1.GetOptions{})
+
+	if getErr != nil {
+		if k8serrors.IsNotFound(getErr) {
+			// Add to the referenced objects if the object isn't found since the consumer may want to watch the object
+			// and resolve the templates again once it is present.
+			t.addToReferencedObjects("/v1", "Secret", ns, secretname)
+		}
+
+		klog.Errorf("Error Getting secret:  %v", getErr)
+		err := fmt.Errorf("failed to get the secret %s from %s: %w", secretname, ns, getErr)
+
+		return nil, err
+	}
+
+	data := make(map[string]interface{})
+
+	for key, val := range secret.Data {
+		// when using corev1 secret api, the data is returned decoded,
+		// re-encododing to be able to use it in the referencing secret
+		sEnc := base64.StdEncoding.EncodeToString(val)
+		data[key] = sEnc
+	}
+
+	// add this Secret to list of  Objs referenced by the template
+	t.addToReferencedObjects("/v1", "Secret", secret.Namespace, secret.Name)
+
+	return data, nil
+}
+
+// copies all data in the given Secret, namespace.
+func (t *TemplateResolver) copySecretData(namespace string, secretname string) (string, error) {
+	klog.V(2).Infof("copySecretData for namespace: %v, secretname: %v", namespace, secretname)
+
+	data, err := t.copySecretDataBase(namespace, secretname)
+	if err != nil {
+		return "", err
+	}
+
+	rawData, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+
+	return string(rawData), nil
+}
+
+// copySecretDataProtected wraps copySecretData and encrypts the output value using the "protect" method.
+func (t *TemplateResolver) copySecretDataProtected(namespace string, secretName string) (string, error) {
+	data, err := t.copySecretDataBase(namespace, secretName)
+	if err != nil {
+		return "", err
+	}
+
+	for key, val := range data {
+		data[key], err = t.protect(fmt.Sprint(val))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	rawData, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+
+	return string(rawData), nil
+}
+
 // retrieves value for the key in the given Configmap, namespace.
 func (t *TemplateResolver) fromConfigMap(namespace string, cmapname string, key string) (string, error) {
 	klog.V(2).Infof("fromConfigMap for namespace: %v, configmap name: %v, key:%v", namespace, cmapname, key)
@@ -94,6 +174,49 @@ func (t *TemplateResolver) fromConfigMap(namespace string, cmapname string, key 
 	t.addToReferencedObjects("/v1", "ConfigMap", namespace, cmapname)
 
 	return keyVal, nil
+}
+
+// copies data values in the given Configmap, namespace.
+func (t *TemplateResolver) copyConfigMapData(namespace string, cmapname string) (string, error) {
+	klog.V(2).Infof("copyConfigMapData for namespace: %v, configmap name: %v", namespace, cmapname)
+
+	ns, err := t.getNamespace("copyConfigMapData", namespace)
+	if err != nil {
+		return "", err
+	}
+
+	configmapsClient := (*t.kubeClient).CoreV1().ConfigMaps(ns)
+	configmap, getErr := configmapsClient.Get(context.TODO(), cmapname, metav1.GetOptions{})
+
+	if getErr != nil {
+		if k8serrors.IsNotFound(getErr) {
+			// Add to the referenced objects if the object isn't found since the consumer may want to watch the object
+			// and resolve the templates again once it is present.
+			t.addToReferencedObjects("/v1", "ConfigMap", ns, cmapname)
+		}
+
+		klog.Errorf("Error getting configmap:  %v", getErr)
+		err := fmt.Errorf("failed getting the ConfigMap %s from %s: %w", cmapname, ns, getErr)
+
+		return "", err
+	}
+
+	klog.V(2).Infof("Configmap is %v", configmap)
+
+	data := make(map[string]interface{})
+
+	for key, val := range configmap.Data {
+		data[key] = val
+	}
+
+	rawData, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+
+	t.addToReferencedObjects("/v1", "ConfigMap", namespace, cmapname)
+
+	return string(rawData), nil
 }
 
 // convenience functions to base64 encode string values

--- a/pkg/templates/k8sresource_funcs_test.go
+++ b/pkg/templates/k8sresource_funcs_test.go
@@ -4,6 +4,8 @@
 package templates
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -115,6 +117,228 @@ func TestFromConfigMap(t *testing.T) {
 			}
 		} else if val != test.expectedResult {
 			t.Fatalf("expected : %s , got : %s", test.expectedResult, val)
+		}
+	}
+}
+
+func TestCopySecretData(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		inputNs         string
+		inputSecretName string
+		inputKey        string
+		lookupNamespace string
+		expectedResult  string
+		expectedErr     error
+	}{
+		{"testns", "testsecret", "secretkey1", "", "secretkey1Val", nil},       // green-path test
+		{"testns", "testsecret", "secretkey2", "", "secretkey2Val", nil},       // green-path test
+		{"testns", "testsecret", "secretkey2", "testns", "secretkey2Val", nil}, // green-path test
+		{
+			"testns",
+			"idontexist",
+			"secretkey1",
+			"",
+			"secretkey2Val",
+			errors.New(`failed to get the secret idontexist from testns: secrets "idontexist" not found`),
+		}, // error : nonexistant secret
+		{"testns", "testsecret", "blah", "", "", nil}, // error : nonexistant key
+		{
+			"testns",
+			"testsecret",
+			"secretkey2",
+			"policies-ns",
+			"",
+			errors.New("the namespace argument passed to copySecretData is restricted to policies-ns"),
+		}, // error : restricted input namespace
+	}
+
+	for _, test := range testcases {
+		resolver, err := NewResolver(&k8sClient, k8sConfig, Config{LookupNamespace: test.lookupNamespace})
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+
+		val, err := resolver.copySecretData(test.inputNs, test.inputSecretName)
+
+		if err != nil {
+			if test.expectedErr == nil {
+				t.Fatalf(err.Error())
+			}
+
+			if !strings.EqualFold(test.expectedErr.Error(), err.Error()) {
+				t.Fatalf("expected err: %s got err: %s", test.expectedErr, err)
+			}
+		} else {
+			jsonval, err := yamlToJSON([]byte(val))
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+			var contents map[string]string
+			err = json.Unmarshal(jsonval, &contents)
+
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			if contents[test.inputKey] != base64encode(test.expectedResult) {
+				t.Fatalf("expected : %s , to equal : %s", base64encode(test.expectedResult), contents[test.inputKey])
+			}
+		}
+	}
+}
+
+func TestCopySecretDataProtected(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		inputNs         string
+		inputSecretName string
+		inputKey        string
+		lookupNamespace string
+		expectedResult  string
+		expectedErr     error
+	}{
+		{
+			"testns", "testsecret", "secretkey1", "",
+			"$ocm_encrypted:c6PNhsEfbM9NRUqeJ+HbcECCyVdFnRbLdd+n8r1fS9M=", nil,
+		}, // green-path test
+		{
+			"testns", "testsecret", "secretkey2", "",
+			"$ocm_encrypted:VlXOhKuKGoHimHAYlQ2xz5EBw7mriqtt7fEP5ShP5cw=", nil,
+		}, // green-path test
+		{
+			"testns", "testsecret", "secretkey2", "testns",
+			"$ocm_encrypted:VlXOhKuKGoHimHAYlQ2xz5EBw7mriqtt7fEP5ShP5cw=", nil,
+		}, // green-path test
+		{
+			"testns",
+			"idontexist",
+			"secretkey1",
+			"",
+			"secretkey2Val",
+			errors.New(`failed to get the secret idontexist from testns: secrets "idontexist" not found`),
+		}, // error : nonexistant secret
+		{"testns", "testsecret", "blah", "", "", nil}, // error : nonexistant key
+		{
+			"testns",
+			"testsecret",
+			"secretkey2",
+			"policies-ns",
+			"",
+			errors.New("the namespace argument passed to copySecretData is restricted to policies-ns"),
+		}, // error : restricted input namespace
+	}
+
+	for _, test := range testcases {
+		iv := bytes.Repeat([]byte{byte('I')}, IVSize)
+
+		resolver, err := NewResolver(&k8sClient, k8sConfig, Config{
+			EncryptionConfig: EncryptionConfig{
+				AESKey:               bytes.Repeat([]byte{byte('A')}, 256/8),
+				EncryptionEnabled:    true,
+				InitializationVector: iv,
+			},
+			LookupNamespace: test.lookupNamespace,
+		})
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+
+		val, err := resolver.copySecretDataProtected(test.inputNs, test.inputSecretName)
+
+		if err != nil {
+			if test.expectedErr == nil {
+				t.Fatalf(err.Error())
+			}
+
+			if !strings.EqualFold(test.expectedErr.Error(), err.Error()) {
+				t.Fatalf("expected err: %s got err: %s", test.expectedErr, err)
+			}
+		} else {
+			jsonval, err := yamlToJSON([]byte(val))
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+			var contents map[string]string
+			err = json.Unmarshal(jsonval, &contents)
+
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			if contents[test.inputKey] != test.expectedResult {
+				t.Fatalf("expected : %s , to equal : %s", test.expectedResult, contents[test.inputKey])
+			}
+		}
+	}
+}
+
+func TestCopyConfigMapData(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		inputNs         string
+		inputCMname     string
+		inputKey        string
+		lookupNamespace string
+		expectedResult  string
+		expectedErr     error
+	}{
+		{"testns", "testconfigmap", "cmkey1", "", "cmkey1Val", nil},
+		{"testns", "testconfigmap", "cmkey2", "", "cmkey2Val", nil},
+		{"testns", "testconfigmap", "cmkey2", "testns", "cmkey2Val", nil},
+		{
+			"testns",
+			"idontexist",
+			"cmkey1",
+			"",
+			"cmkey1Val",
+			errors.New(`failed getting the ConfigMap idontexist from testns: configmaps "idontexist" not found`),
+		},
+		{"testns", "testconfigmap", "idontexist", "", "", nil},
+		{
+			"testns",
+			"testconfigmap",
+			"cmkey1",
+			"policies-ns",
+			"cmkey1Val",
+			errors.New("the namespace argument passed to copyConfigMapData is restricted to policies-ns"),
+		},
+	}
+
+	for _, test := range testcases {
+		resolver, err := NewResolver(&k8sClient, k8sConfig, Config{LookupNamespace: test.lookupNamespace})
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+
+		val, err := resolver.copyConfigMapData(test.inputNs, test.inputCMname)
+
+		if err != nil {
+			if test.expectedErr == nil {
+				t.Fatalf(err.Error())
+			}
+
+			if !strings.EqualFold(test.expectedErr.Error(), err.Error()) {
+				t.Fatalf("expected err: %s got err: %s", test.expectedErr, err)
+			}
+		} else {
+			jsonval, err := yamlToJSON([]byte(val))
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+			var contents map[string]string
+			err = json.Unmarshal(jsonval, &contents)
+
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			if contents[test.inputKey] != test.expectedResult {
+				t.Fatalf("expected : %s , to equal : %s", test.expectedResult, contents[test.inputKey])
+			}
 		}
 	}
 }


### PR DESCRIPTION
Use the template feature to copy the data contents of a configmap or secret to another resource as defined in a policy.

Refs:
 - https://issues.redhat.com/browse/ACM-2611

Signed-off-by: Gus Parvin <gparvin@redhat.com>