### PR TITLE
Enable use labels for template Lookup function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/spf13/cast v1.5.0
 	github.com/stolostron/kubernetes-dependency-watches v0.0.0-20221007134235-7551d84cf688
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.23.9
 	k8s.io/apimachinery v0.23.9
@@ -39,7 +40,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/go.sum
+++ b/go.sum
@@ -524,6 +524,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -686,8 +688,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=

--- a/pkg/templates/generic_lookup_func_test.go
+++ b/pkg/templates/generic_lookup_func_test.go
@@ -4,8 +4,11 @@ package templates
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
+
+	"golang.org/x/exp/slices"
 )
 
 func TestLookup(t *testing.T) {
@@ -76,6 +79,201 @@ func TestLookup(t *testing.T) {
 						"Received: ApiVersion= %s, Kind= %s, Name= %s , NS= %s",
 					test.inputAPIVersion, test.inputKind, test.inputName, test.inputNs,
 					val["apiVersion"], val["kind"], valMetadata["name"], valMetadata["namespace"])
+			}
+		}
+	}
+}
+
+func TestLookupWithLabels(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		inputNs          string
+		inputAPIVersion  string
+		inputKind        string
+		inputName        string
+		lookupNamespace  string
+		labelSelector    []string
+		expectedObjCount int
+		expectedErr      error
+		expectedExists   bool
+		expectedObjNames []string
+	}{
+		{
+			"testns",
+			"v1",
+			"ConfigMap",
+			"testcm-envc",
+			"",
+			nil,
+			1,
+			nil,
+			true,
+			[]string{"testcm-envc"},
+		},
+		{
+			"testns",
+			"v1",
+			"ConfigMap",
+			"",
+			"",
+			nil,
+			4,
+			nil,
+			true,
+			[]string{"testconfigmap", "testcm-enva", "testcm-envb", "testcm-envc"},
+		},
+		{
+			"testns",
+			"v1",
+			"ConfigMap",
+			"",
+			"",
+			[]string{"app=test"},
+			3,
+			nil,
+			true,
+			[]string{"testcm-enva", "testcm-envb", "testcm-envc"},
+		},
+		{
+			"testns",
+			"v1",
+			"ConfigMap",
+			"",
+			"",
+			[]string{"env=a"},
+			1,
+			nil,
+			true,
+			[]string{"testcm-enva"},
+		},
+		{
+			"testns",
+			"v1",
+			"ConfigMap",
+			"",
+			"",
+			[]string{"env in (a)"},
+			1,
+			nil,
+			true,
+			[]string{"testcm-enva"},
+		},
+		{
+			"testns",
+			"v1",
+			"ConfigMap",
+			"",
+			"",
+			[]string{"env in (a,b)"},
+			2,
+			nil,
+			true,
+			[]string{"testcm-enva", "testcm-envb"},
+		},
+		{
+			"testns",
+			"v1",
+			"ConfigMap",
+			"",
+			"",
+			[]string{"env in (d)"},
+			0,
+			nil,
+			true, // Note ExpectedObject = true as lookup returns empty list
+			nil,
+		},
+		{
+			"testns",
+			"v1",
+			"ConfigMap",
+			"",
+			"",
+			[]string{"app=test", "env in (c)"},
+			1,
+			nil,
+			true,
+			[]string{"testcm-envc"},
+		},
+		{
+			"testns",
+			"v1",
+			"ConfigMap",
+			"",
+			"",
+			[]string{"env IN (a)"},
+			0,
+			errors.New("unable to parse requirement: found 'IN', expected: in, notin, =, ==, !=, gt, lt"),
+			false,
+			nil,
+		},
+	}
+
+	for _, test := range testcases {
+		resolver, err := NewResolver(&k8sClient, k8sConfig, Config{LookupNamespace: test.lookupNamespace})
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+
+		// prevent linter critic for unslicing.  this is required to duplicate passing multiple args as a user would
+		//nolint:gocritic
+		val, err := resolver.lookup(test.inputAPIVersion,
+			test.inputKind,
+			test.inputNs,
+			test.inputName,
+			test.labelSelector[:]...)
+
+		if err != nil {
+			if test.expectedErr == nil {
+				t.Fatalf(err.Error())
+			}
+
+			if !strings.EqualFold(test.expectedErr.Error(), err.Error()) {
+				t.Fatalf("expected err: %s got err: %s", test.expectedErr, err)
+			}
+		} else if test.expectedErr != nil {
+			t.Fatalf("An error was expected but not returned %s", test.expectedErr)
+		}
+
+		if test.expectedExists {
+			if len(val) == 0 {
+				t.Fatal("An object was expected but not returned")
+			}
+		} else if len(val) != 0 {
+			t.Fatalf("An object was unexpected but one was returned: %v", test)
+		}
+
+		if len(resolver.referencedObjects) != test.expectedObjCount {
+			t.Fatalf("expected referenced object count: %d , got : %d",
+				test.expectedObjCount, len(resolver.referencedObjects))
+		} else if test.expectedExists && test.inputName != "" {
+			valMetadata := val["metadata"].(map[string]interface{})
+			if val["apiVersion"] != test.inputAPIVersion || val["kind"] != test.inputKind ||
+				valMetadata["name"] != test.inputName || valMetadata["namespace"] != test.inputNs {
+				t.Fatalf(
+					"expected:  ApiVersion= %s, Kind= %s, Name= %s, NS= %s,"+
+						"Received: ApiVersion= %s, Kind= %s, Name= %s , NS= %s",
+					test.inputAPIVersion, test.inputKind, test.inputName, test.inputNs,
+					val["apiVersion"], val["kind"], valMetadata["name"], valMetadata["namespace"])
+			}
+		} else if test.expectedExists && test.inputName == "" {
+			for _, lstObj := range val["items"].([]interface{}) {
+				refObject := lstObj.(map[string]interface{})
+				refObjMetadata := refObject["metadata"].(map[string]interface{})
+				if refObject["apiVersion"] != test.inputAPIVersion || refObject["kind"] != test.inputKind ||
+					refObjMetadata["namespace"] != test.inputNs {
+					t.Fatalf(
+						"expected:  ApiVersion= %s, Kind= %s, NS= %s,"+
+							"Received: ApiVersion= %s, Kind= %s, NS= %s",
+						test.inputAPIVersion, test.inputKind, test.inputNs,
+						refObject["apiVersion"], refObject["kind"], refObjMetadata["namespace"])
+				}
+
+				// Verify the objects returned by label match the name(s) we expect
+				if len(test.expectedObjNames) > 0 &&
+					!(slices.Contains(test.expectedObjNames, fmt.Sprintf("%v", refObjMetadata["name"]))) {
+					t.Fatalf("Lookup returned %v, not found in %v", refObjMetadata["name"], test.expectedObjNames)
+				}
 			}
 		}
 	}

--- a/pkg/templates/templates_suite_test.go
+++ b/pkg/templates/templates_suite_test.go
@@ -112,7 +112,76 @@ func setUp() {
 		},
 	}
 
+	// sample configmaps to test different label selectors
+	configmaplba := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testcm-enva",
+			Labels: map[string]string{
+				"app": "test",
+				"env": "a",
+			},
+		},
+		Data: map[string]string{
+			"cmkey1": "cmkey1Val",
+		},
+	}
+
+	// sample configmap env b
+	configmaplbb := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testcm-envb",
+			Labels: map[string]string{
+				"app": "test",
+				"env": "b",
+			},
+		},
+		Data: map[string]string{
+			"cmkey1": "cmkey1Val",
+		},
+	}
+
+	// sample configmap env c
+	configmaplbc := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testcm-envc",
+			Labels: map[string]string{
+				"app": "test",
+				"env": "c",
+			},
+		},
+		Data: map[string]string{
+			"cmkey1": "cmkey1Val",
+		},
+	}
+
 	_, err = k8sClient.CoreV1().ConfigMaps(testNs).Create(ctx, &configmap, metav1.CreateOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+
+	_, err = k8sClient.CoreV1().ConfigMaps(testNs).Create(ctx, &configmaplba, metav1.CreateOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+
+	_, err = k8sClient.CoreV1().ConfigMaps(testNs).Create(ctx, &configmaplbb, metav1.CreateOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+
+	_, err = k8sClient.CoreV1().ConfigMaps(testNs).Create(ctx, &configmaplbc, metav1.CreateOptions{})
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
Use Kubernetes  label selectors to filter results of the lookup function when returning a list of objects.

Refs:
 - https://issues.redhat.com/browse/ACM-4855

Signed-off-by: Brian Jarvis <bjarvis@redhat.com>