### PR TITLE
Restrict lookups of cluster-scoped resources

### DIFF
--- a/pkg/templates/clusterconfig_funcs.go
+++ b/pkg/templates/clusterconfig_funcs.go
@@ -26,7 +26,7 @@ func (t *TemplateResolver) fromClusterClaim(claimname string) (string, error) {
 		return "", errors.New(msg)
 	}
 
-	dclient, dclientErr := t.getDynamicClient(clusterClaimAPIVersion, "ClusterClaim", "")
+	dclient, dclientErr := t.getDynamicClient(clusterClaimAPIVersion, "ClusterClaim", "", claimname)
 	if dclientErr != nil {
 		err := fmt.Errorf("failed to get the cluster claim %s: %w", claimname, dclientErr)
 

--- a/pkg/templates/generic_lookup_func_test.go
+++ b/pkg/templates/generic_lookup_func_test.go
@@ -278,3 +278,131 @@ func TestLookupWithLabels(t *testing.T) {
 		}
 	}
 }
+
+func TestLookupClusterScoped(t *testing.T) {
+	t.Parallel()
+
+	clusterScopedErr := ClusterScopedLookupRestrictedError{"Node", "foo"}
+
+	testcases := []struct {
+		inputNs          string
+		inputAPIVersion  string
+		inputKind        string
+		inputName        string
+		lookupNamespace  string
+		allowlist        []ClusterScopedObjectIdentifier
+		expectedObjCount int
+		expectedErr      error
+		expectedExists   bool
+	}{
+		// No allowlist
+		{"", "v1", "Node", "foo", "", nil, 1, nil, false},
+		{"policies-ns", "v1", "Node", "foo", "", nil, 1, nil, false},
+		{"", "v1", "Node", "foo", "policies-ns", nil, 0, clusterScopedErr, false},
+		{"policies-ns", "v1", "Node", "foo", "policies-ns", nil, 0, clusterScopedErr, false},
+		// With an allowlist matching the resource
+		{
+			"",
+			"v1",
+			"Node",
+			"foo",
+			"policies-ns",
+			[]ClusterScopedObjectIdentifier{{"*", "*", "*"}},
+			1,
+			nil,
+			false,
+		},
+		{
+			"",
+			"v1",
+			"Node",
+			"foo",
+			"policies-ns",
+			[]ClusterScopedObjectIdentifier{{"", "Node", "*"}},
+			1,
+			nil,
+			false,
+		},
+		{
+			"",
+			"v1",
+			"Node",
+			"foo",
+			"policies-ns",
+			[]ClusterScopedObjectIdentifier{{"", "Node", "foo"}},
+			1,
+			nil,
+			false,
+		},
+		// With an allowlist not matching the resource
+		{
+			"",
+			"v1",
+			"Node",
+			"foo",
+			"policies-ns",
+			[]ClusterScopedObjectIdentifier{{"", "Node", "bar"}},
+			0,
+			clusterScopedErr,
+			false,
+		},
+		{
+			"",
+			"v1",
+			"Node",
+			"foo",
+			"policies-ns",
+			[]ClusterScopedObjectIdentifier{{"myapi.com", "Node", "foo"}},
+			0,
+			clusterScopedErr,
+			false,
+		},
+	}
+
+	for _, test := range testcases {
+		resolver, err := NewResolver(&k8sClient, k8sConfig, Config{
+			LookupNamespace:        test.lookupNamespace,
+			ClusterScopedAllowList: test.allowlist,
+		})
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+
+		val, err := resolver.lookup(test.inputAPIVersion, test.inputKind, test.inputNs, test.inputName)
+
+		if err != nil {
+			if test.expectedErr == nil {
+				t.Fatalf(err.Error())
+			}
+
+			if !strings.EqualFold(test.expectedErr.Error(), err.Error()) {
+				t.Fatalf("expected err: %s got err: %s", test.expectedErr, err)
+			}
+		} else if test.expectedErr != nil {
+			t.Fatalf("An error was expected but not returned %s", test.expectedErr)
+		}
+
+		if test.expectedExists {
+			if len(val) == 0 {
+				t.Fatal("An object was expected but not returned")
+			}
+		} else if len(val) != 0 {
+			t.Fatal("An object was unexpected but one was returned")
+		}
+
+		if len(resolver.referencedObjects) != test.expectedObjCount {
+			t.Fatalf("expected referenced object count: %d , got : %d",
+				test.expectedObjCount, len(resolver.referencedObjects))
+		} else if test.expectedExists && test.expectedObjCount != 0 {
+			valMetadata := val["metadata"].(map[string]interface{})
+			if val["apiVersion"] != test.inputAPIVersion || val["kind"] != test.inputKind ||
+				valMetadata["name"] != test.inputName || valMetadata["namespace"] != test.inputNs {
+				t.Fatalf(
+					"expected:  ApiVersion= %s, Kind= %s, Name= %s, NS= %s,"+
+						"Received: ApiVersion= %s, Kind= %s, Name= %s , NS= %s",
+					test.inputAPIVersion, test.inputKind, test.inputName, test.inputNs,
+					val["apiVersion"], val["kind"], valMetadata["name"], valMetadata["namespace"])
+			}
+		}
+	}
+}

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -74,6 +74,11 @@ var (
 // - LookupNamespace is the namespace to restrict "lookup" template functions (e.g. fromConfigMap)
 // to. If this is not set (i.e. an empty string), then all namespaces can be used.
 //
+// - ClusterScopedAllowList is a list of cluster-scoped object identifiers (group, kind, name) which
+// are allowed to be used in "lookup" calls even when LookupNamespace is set. A wildcard value `*`
+// may be used in any or all of the fields. The default behavior when LookupNamespace is set is to
+// deny all cluster-scoped lookups.
+//
 // - StartDelim customizes the start delimiter used to distinguish a template action. This defaults
 // to "{{". If StopDelim is set, this must also be set.
 //
@@ -87,11 +92,18 @@ type Config struct {
 	AdditionalIndentation uint
 	DisabledFunctions     []string
 	EncryptionConfig
-	KubeAPIResourceList []*metav1.APIResourceList
-	LookupNamespace     string
-	StartDelim          string
-	StopDelim           string
-	InputIsYAML         bool
+	KubeAPIResourceList    []*metav1.APIResourceList
+	LookupNamespace        string
+	ClusterScopedAllowList []ClusterScopedObjectIdentifier
+	StartDelim             string
+	StopDelim              string
+	InputIsYAML            bool
+}
+
+type ClusterScopedObjectIdentifier struct {
+	Group string
+	Kind  string
+	Name  string
 }
 
 // EncryptionConfig is a struct containing configuration for template encryption/decryption functionality.


### PR DESCRIPTION
In some cases, it was possible to do a cluster-scoped lookup, despite `LookupNamespace` being set on the config, which was intended to prevent this. That is fixed, and more thoroughly tested.

A new config field `ClusterScopedAllowList` was added to allow specific cluster-scoped resources to be used in `lookup` when `LookupNamespace` is set.