### PR TITLE
WIP: Cache GVK to GVR resolution

### DIFF
--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -136,6 +136,9 @@ func doResolveTest(t *testing.T, test resolveTestCase) {
 			t.Fatalf("%s expected : '%s' , got : '%s'", test.inputTmpl, test.expectedResult, val)
 		}
 	}
+
+	// Not actually useful but it adds test coverage
+	resolver.ClearCache()
 }
 
 func TestResolveTemplateDefaultConfig(t *testing.T) {


### PR DESCRIPTION
Additionally, this also makes getting the GVR more efficient when an APIResourceList isn't provided in the configuration. The dynamic client is now also cached so it's not reinstantiated for every lookup.

Relates:
https://issues.redhat.com/browse/ACM-7402