### PR TITLE
Add two caching modes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/spf13/cast v1.5.0
-	github.com/stolostron/kubernetes-dependency-watches v0.2.0
+	github.com/stolostron/kubernetes-dependency-watches v0.5.1
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.4
@@ -13,6 +13,7 @@ require (
 	k8s.io/client-go v0.26.4
 	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.14.6
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -20,7 +21,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.10.2 // indirect
-	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
@@ -34,7 +34,6 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
-	github.com/jellydator/ttlcache/v3 v3.0.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
@@ -49,7 +48,6 @@ require (
 	golang.org/x/crypto v0.8.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/term v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
@@ -64,5 +62,4 @@ require (
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,7 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
-github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
@@ -52,6 +51,7 @@ github.com/go-openapi/jsonreference v0.20.2 h1:3sVjiK66+uXK/6oQ8xgcRKcFgQ5KXa2Kv
 github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En5Ap4rVB5KVcIDZG2k=
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -86,6 +86,7 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
@@ -97,8 +98,6 @@ github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
-github.com/jellydator/ttlcache/v3 v3.0.1 h1:cHgCSMS7TdQcoprXnWUptJZzyFsqs18Lt8VVhRuZYVU=
-github.com/jellydator/ttlcache/v3 v3.0.1/go.mod h1:WwTaEmcXQ3MTjOm4bsZoDFiCu/hMvNWLO1w67RXz6h4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -129,8 +128,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.6.0 h1:9t9b9vRUbFq3C4qKFCGkVuq/fIHji802N1nrtkh1mNc=
-github.com/onsi/gomega v1.24.1 h1:KORJXNNTzJXzu4ScJWssJfJMnJ+2QJqhoQSRwNlze9E=
+github.com/onsi/ginkgo/v2 v2.9.1 h1:zie5Ly042PD3bsCvsSOPvRnFwyo3rKe64TJlD6nu0mk=
+github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -153,8 +152,8 @@ github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
-github.com/stolostron/kubernetes-dependency-watches v0.2.0 h1:5MWK4xv5OOglyov7qoiKQ/M1Q5MTrEKSWuh/ed3zauQ=
-github.com/stolostron/kubernetes-dependency-watches v0.2.0/go.mod h1:zFj8nBxKVn9QtmQIMlM0QSIqRSCKoMUtoY8G6Q+LJAc=
+github.com/stolostron/kubernetes-dependency-watches v0.5.1 h1:NZ9N5/VWtwKcawgg4TGI4A5+weSkLrXZMjU7w91xfvU=
+github.com/stolostron/kubernetes-dependency-watches v0.5.1/go.mod h1:8vRsL1GGBw0jjCwP8CH8d30NVNYKhUy0rdBSQZ2znx8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -173,7 +172,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
-go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -221,8 +219,6 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
-golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -263,6 +259,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/templates/generic_lookup_func.go
+++ b/pkg/templates/generic_lookup_func.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/stolostron/kubernetes-dependency-watches/client"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog"
 )
@@ -31,253 +32,229 @@ func (e ClusterScopedLookupRestrictedError) Error() string {
 // lookupNamespace. If it's not, an error is returned. It then returns the namespace
 // that should be used. If the target namespace is not set and the lookupNamespace
 // configuration is, then the namespace of lookupNamespace is returned for convenience.
-func (t *TemplateResolver) getNamespace(funcName, namespace string) (string, error) {
+func (t *TemplateResolver) getNamespace(namespace string, lookupNamespace string) (string, error) {
 	// When lookupNamespace is an empty string, there are no namespace restrictions.
-	if t.config.LookupNamespace != "" {
+	if lookupNamespace != "" {
 		// If lookupNamespace is set but namespace is an empty string, then default
 		// to lookupNamespace for convenience
 		if namespace == "" {
-			return t.config.LookupNamespace, nil
+			return lookupNamespace, nil
 		}
 
-		if t.config.LookupNamespace != namespace {
-			msg := fmt.Sprintf(
-				"the namespace argument passed to %s is restricted to %s",
-				funcName,
-				t.config.LookupNamespace,
-			)
-			klog.Error(msg)
-
-			return "", errors.New(msg)
+		if lookupNamespace != namespace {
+			return "", fmt.Errorf("%w to %s", ErrRestrictedNamespace, lookupNamespace)
 		}
 	}
 
 	return namespace, nil
 }
 
-func (t *TemplateResolver) lookup(
-	apiversion string, kind string, namespace string, rsrcname string, labelselector ...string,
+func (t *TemplateResolver) getOrList(
+	options *ResolveOptions,
+	apiVersion string,
+	kind string,
+	namespace string,
+	name string,
+	labelSelector ...string,
 ) (
 	map[string]interface{}, error,
 ) {
-	klog.V(2).Infof("lookup :  %v, %v, %v, %v", apiversion, kind, namespace, rsrcname)
-
-	result := make(map[string]interface{})
-
-	ns, err := t.getNamespace("lookup", namespace)
-	if err != nil {
-		return result, err
+	if options == nil {
+		options = &ResolveOptions{}
 	}
 
-	// get dynamic Client for the given GVK and namespace
-	dclient, dclientErr := t.getDynamicClient(apiversion, kind, ns, rsrcname)
-	if dclientErr != nil {
-		// Treat a missing API resource as if an object was not found.
-		if errors.Is(dclientErr, ErrMissingAPIResource) {
-			return result, nil
+	if apiVersion == "" || kind == "" {
+		return nil, errors.New("the apiVersion and kind are required")
+	}
+
+	ns, err := t.getNamespace(namespace, options.LookupNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	gvk := schema.GroupVersionKind{
+		Group:   gv.Group,
+		Version: gv.Version,
+		Kind:    kind,
+	}
+
+	parsedSelector := labels.NewSelector()
+	// If labelSelector is defined, and is not an empty string, then add the labels to the listOptions
+	// Note there can be multiple values passed to labelSelector so we need to treat it as an array
+	// The ListOption requires a single string value.
+	if len(labelSelector) > 0 && labelSelector[0] != "" {
+		// We use the labels.Parse to validate the selector given.
+		// this should give us a better error output if the user misconfigured the selector
+		parsedSelector, err = labels.Parse(strings.Join(labelSelector, ","))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var scopedGVRObj client.ScopedGVR
+	if t.dynamicWatcher != nil {
+		scopedGVRObj, err = t.dynamicWatcher.GVKToGVR(gvk)
+	} else {
+		scopedGVRObj, err = t.tempCallCache.GVKToGVR(gvk)
+	}
+
+	if err != nil {
+		if errors.Is(err, client.ErrNoVersionedResource) {
+			return nil, ErrMissingAPIResource
 		}
 
-		return result, dclientErr
+		return nil, err
 	}
 
-	// if resourcename is  set then get the specific resource
-	// else get list of all resources for that (gvk, ns)
-	var lookupErr error
+	if !scopedGVRObj.Namespaced && options.LookupNamespace != "" {
+		rsrcIdentifier := ClusterScopedObjectIdentifier{
+			Group: scopedGVRObj.Group,
+			Kind:  kind,
+			Name:  name,
+		}
+		if !onAllowlist(options.ClusterScopedAllowList, rsrcIdentifier) {
+			return nil, ClusterScopedLookupRestrictedError{kind, name}
+		}
+	}
 
-	if rsrcname != "" {
-		getObj, lookupErr := dclient.Get(context.TODO(), rsrcname, metav1.GetOptions{})
-		if lookupErr != nil {
-			if apierrors.IsNotFound(lookupErr) {
-				// Add to the referenced objects if the object isn't found since the consumer may want to watch the
-				// object and resolve the templates again once it is present.
-				t.addToReferencedObjects(apiversion, kind, ns, rsrcname)
+	if t.dynamicWatcher != nil {
+		if name == "" {
+			result, err := t.dynamicWatcher.List(*options.Watcher, gvk, ns, parsedSelector)
+			if err != nil {
+				return nil, err
 			}
-		} else {
-			result = getObj.UnstructuredContent()
-			t.addToReferencedObjects(apiversion, kind, ns, rsrcname)
+
+			resultList := unstructured.UnstructuredList{Items: result}
+
+			return resultList.UnstructuredContent(), nil
+		}
+
+		result, err := t.dynamicWatcher.Get(*options.Watcher, gvk, ns, name)
+		if err != nil {
+			return nil, err
+		}
+
+		if result == nil {
+			return nil, apierrors.NewNotFound(scopedGVRObj.GroupResource(), name)
+		}
+
+		return result.UnstructuredContent(), nil
+	}
+
+	// The dynamic watcher is not used, so use the temporary call cache
+	lookupID := client.ObjectIdentifier{
+		Group:     gvk.Group,
+		Version:   gvk.Version,
+		Kind:      gvk.Kind,
+		Namespace: ns,
+		Name:      name,
+		Selector:  parsedSelector.String(),
+	}
+
+	cachedResults, err := t.tempCallCache.FromObjectIdentifier(lookupID)
+	if err != nil {
+		if !errors.Is(err, client.ErrNoCacheEntry) {
+			return nil, err
 		}
 	} else {
-		listOptions := metav1.ListOptions{}
-
-		// If labelSelector is defined, and is not an empty string, then add the labels to the listOptions
-		// Note there can be multiple values passed to labelselector so we need to treat it as an array
-		// The ListOption requires a single string value.
-		if len(labelselector) > 0 && labelselector[0] != "" {
-			// We use the labels.Parse to validate the selector given.
-			// this should give us a better error output if the user misconfigured the selector
-			parsedSelector, lookupErr := labels.Parse(strings.Join(labelselector, ","))
-			if lookupErr != nil {
-				return nil, lookupErr
+		// Check if this is a Get or List query
+		if name != "" {
+			if len(cachedResults) > 0 {
+				return cachedResults[0].UnstructuredContent(), nil
 			}
 
-			klog.V(2).Infof("lookup labels:  %v", parsedSelector)
-			listOptions = metav1.ListOptions{
-				LabelSelector: parsedSelector.String(),
-			}
+			return nil, nil
 		}
-		listObj, lookupErr := dclient.List(context.TODO(), listOptions)
-		if lookupErr == nil {
-			result = listObj.UnstructuredContent()
-			for _, item := range listObj.Items {
-				t.addToReferencedObjects(item.GetAPIVersion(), item.GetKind(), ns, item.GetName())
-			}
-		}
+
+		resultList := unstructured.UnstructuredList{Items: cachedResults}
+
+		return resultList.UnstructuredContent(), nil
 	}
 
-	if lookupErr != nil {
-		if apierrors.IsNotFound(lookupErr) {
-			lookupErr = nil
+	// It's not cached so it must be retrieved using the dynamic client and then cached
+
+	var dynamciClientRes dynamic.ResourceInterface
+
+	if scopedGVRObj.Namespaced && ns != "" {
+		dynamciClientRes = t.dynamicClient.Resource(scopedGVRObj.GroupVersionResource).Namespace(ns)
+	} else {
+		dynamciClientRes = t.dynamicClient.Resource(scopedGVRObj.GroupVersionResource)
+	}
+
+	if name == "" {
+		resultUnstructuredList, err := dynamciClientRes.List(
+			context.TODO(), metav1.ListOptions{LabelSelector: parsedSelector.String()},
+		)
+		if err != nil {
+			return nil, err
 		}
+
+		t.tempCallCache.CacheFromObjectIdentifier(lookupID, resultUnstructuredList.Items)
+
+		// Strip out the other metadata to match what is returned from the cache
+		resultUnstructuredList = &unstructured.UnstructuredList{Items: resultUnstructuredList.Items}
+
+		return resultUnstructuredList.UnstructuredContent(), nil
+	}
+
+	resultUnstructured, err := dynamciClientRes.Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		t.tempCallCache.CacheFromObjectIdentifier(lookupID, []unstructured.Unstructured{*resultUnstructured})
+	}
+
+	if err != nil {
+		// Cache a not found result
+		if apierrors.IsNotFound(err) {
+			t.tempCallCache.CacheFromObjectIdentifier(lookupID, []unstructured.Unstructured{})
+		}
+
+		return nil, err
+	}
+
+	return resultUnstructured.UnstructuredContent(), nil
+}
+
+func (t *TemplateResolver) lookupHelper(
+	options *ResolveOptions,
+) func(string, string, string, string, ...string) (map[string]interface{}, error) {
+	return func(
+		apiVersion string,
+		kind string,
+		namespace string,
+		name string,
+		labelSelector ...string,
+	) (map[string]interface{}, error) {
+		return t.lookup(options, apiVersion, kind, namespace, name, labelSelector...)
+	}
+}
+
+func (t *TemplateResolver) lookup(
+	options *ResolveOptions,
+	apiVersion string,
+	kind string,
+	namespace string,
+	name string,
+	labelSelector ...string,
+) (
+	map[string]interface{}, error,
+) {
+	klog.V(2).Infof("lookup :  %v, %v, %v, %v", apiVersion, kind, namespace, name)
+
+	result, lookupErr := t.getOrList(options, apiVersion, kind, namespace, name, labelSelector...)
+
+	// lookups don't fail on errors
+	if apierrors.IsNotFound(lookupErr) {
+		lookupErr = nil
 	}
 
 	klog.V(2).Infof("lookup result:  %v", result)
 
 	return result, lookupErr
-}
-
-// this func finds the GVR for given GVK and returns a namespaced dynamic client.
-func (t *TemplateResolver) getDynamicClient(
-	apiversion string, kind string, namespace string, name string,
-) (
-	dynamic.ResourceInterface, error,
-) {
-	var dclient dynamic.ResourceInterface
-
-	gvk := schema.FromAPIVersionAndKind(apiversion, kind)
-
-	klog.V(2).Infof("GVK is:  %v", gvk)
-
-	// we have GVK but We need GVR i.e resourcename for kind inorder to create dynamicClient
-	// find ApiResource for given GVK
-	apiResource, findErr := t.findAPIResource(gvk)
-	if findErr != nil {
-		return nil, findErr
-	}
-	// make GVR from ApiResource
-	gvr := schema.GroupVersionResource{
-		Group:    apiResource.Group,
-		Version:  apiResource.Version,
-		Resource: apiResource.Name,
-	}
-	klog.V(2).Infof("GVR is:  %v", gvr)
-
-	if !apiResource.Namespaced && t.config.LookupNamespace != "" {
-		rsrcIdentifier := ClusterScopedObjectIdentifier{
-			Group: apiResource.Group,
-			Kind:  kind,
-			Name:  name,
-		}
-		if !onAllowlist(t.config.ClusterScopedAllowList, rsrcIdentifier) {
-			return nil, ClusterScopedLookupRestrictedError{kind, name}
-		}
-	}
-
-	// get Dynamic Client
-	dclientIntf, dclientErr := dynamic.NewForConfig(t.kubeConfig)
-	if dclientErr != nil {
-		klog.Errorf("Failed to get dynamic client with err: %v", dclientErr)
-
-		return nil, fmt.Errorf("failed to get the dynamic client: %w", dclientErr)
-	}
-
-	// get Dynamic Client for GVR
-	dclientNsRes := dclientIntf.Resource(gvr)
-
-	// get Dynamic Client for GVR for Namespace if namespaced
-	if apiResource.Namespaced && namespace != "" {
-		dclient = dclientNsRes.Namespace(namespace)
-	} else {
-		dclient = dclientNsRes
-	}
-
-	klog.V(2).Infof("dynamic client: %v", dclient)
-
-	return dclient, nil
-}
-
-func (t *TemplateResolver) findAPIResource(gvk schema.GroupVersionKind) (metav1.APIResource, error) {
-	klog.V(2).Infof("GVK is: %v", gvk)
-
-	apiResource := metav1.APIResource{}
-
-	// check if an apiresource list is available already (i.e provided as input to templates)
-	// if not available use api discovery client to get api resource list
-	apiResList := t.config.KubeAPIResourceList
-	if apiResList == nil {
-		var ddErr error
-		apiResList, ddErr = t.discoverAPIResources()
-
-		if ddErr != nil {
-			return apiResource, fmt.Errorf("")
-		}
-	}
-
-	// find apiResourcefor given GVK
-	var groupVersion string
-	if gvk.Group != "" {
-		groupVersion = gvk.Group + "/" + gvk.Version
-	} else {
-		groupVersion = gvk.Version
-	}
-
-	klog.V(2).Infof("GroupVersion is: %v", groupVersion)
-
-	found := false
-
-	for _, apiResGroup := range apiResList {
-		if apiResGroup.GroupVersion == groupVersion {
-			for _, apiRes := range apiResGroup.APIResources {
-				if apiRes.Kind == gvk.Kind {
-					apiResource = apiRes
-					apiResource.Group = gvk.Group
-					apiResource.Version = gvk.Version
-					found = true
-
-					klog.V(2).Infof("found the APIResource: %v", apiResource)
-
-					break
-				}
-			}
-
-			// If the kind isn't found in the matching group version, then the kind doesn't exist.
-			break
-		}
-	}
-
-	if !found {
-		klog.V(2).Infof("The APIResource for the GVK wasn't found: %v", gvk)
-
-		t.missingAPIResource = true
-
-		return apiResource, ErrMissingAPIResource
-	}
-
-	return apiResource, nil
-}
-
-// Configpolicycontroller sets the apiresource list on the template processor
-// So this func shouldnt  execute in the configpolicy flow
-// including this just for completeness.
-func (t *TemplateResolver) discoverAPIResources() ([]*metav1.APIResourceList, error) {
-	klog.V(2).Infof("discover APIResources")
-
-	dd, ddErr := discovery.NewDiscoveryClientForConfig(t.kubeConfig)
-	if ddErr != nil {
-		klog.Errorf("Failed to create the discovery client with err: %v", ddErr)
-
-		return nil, fmt.Errorf("failed to create the discovery client: %w", ddErr)
-	}
-
-	_, apiresourcelist, apiresourcelistErr := dd.ServerGroupsAndResources()
-	if apiresourcelistErr != nil {
-		klog.Errorf("Failed to retrieve apiresourcelist with err: %v", apiresourcelistErr)
-
-		return nil, fmt.Errorf("failed to retrieve apiresourcelist: %w", apiresourcelistErr)
-	}
-
-	klog.V(2).Infof("discovered APIResources: %v", apiresourcelist)
-
-	return apiresourcelist, nil
 }
 
 func onAllowlist(allowlist []ClusterScopedObjectIdentifier, rsrc ClusterScopedObjectIdentifier) bool {

--- a/pkg/templates/sprig_wrapper_test.go
+++ b/pkg/templates/sprig_wrapper_test.go
@@ -9,9 +9,6 @@ import (
 	"testing"
 
 	yaml "gopkg.in/yaml.v3"
-	"k8s.io/client-go/kubernetes"
-	fake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/rest"
 )
 
 func TestGetSprigFunc(t *testing.T) {
@@ -251,9 +248,7 @@ func TestGetSprigFunc(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		var k8sClient kubernetes.Interface = fake.NewSimpleClientset()
-
-		resolver, _ := NewResolver(&k8sClient, &rest.Config{}, Config{})
+		resolver, _ := NewResolver(k8sConfig, Config{})
 
 		policyYAML := `
 ---
@@ -269,7 +264,7 @@ data:
 
 		templateCtx := struct{ Labels map[string]string }{map[string]string{"hello": "world"}}
 
-		resolvedResult, err := resolver.ResolveTemplate(policyJSON, templateCtx)
+		resolvedResult, err := resolver.ResolveTemplate(policyJSON, templateCtx, nil)
 		if err != nil {
 			t.Fatalf("Failed to process the policy YAML: %v\n", err)
 		}

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -635,6 +635,15 @@ func (t *TemplateResolver) GetFromCache(
 	return t.dynamicWatcher.GetFromCache(gvk, namespace, name)
 }
 
+// GetWatchCount returns the total number of active API watch requests which can be used for metrics.
+func (t *TemplateResolver) GetWatchCount() uint {
+	if t.dynamicWatcher != nil {
+		return t.dynamicWatcher.GetWatchCount()
+	}
+
+	return 0
+}
+
 //nolint:wsl
 func (t *TemplateResolver) processForDataTypes(str string) string {
 	// The idea is to remove the quotes enclosing the template if it has toBool, toInt, or toLiteral.

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -5,6 +5,7 @@ package templates
 
 import (
 	"bytes"
+	"context"
 	"crypto/aes"
 	"encoding/json"
 	"errors"
@@ -14,15 +15,16 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/spf13/cast"
 	"github.com/stolostron/kubernetes-dependency-watches/client"
 	yaml "gopkg.in/yaml.v3"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 const (
@@ -34,50 +36,31 @@ const (
 )
 
 var (
-	ErrAESKeyNotSet                      = errors.New("AESKey must be set to use this encryption mode")
-	ErrInvalidAESKey                     = errors.New("the AES key is invalid")
-	ErrInvalidB64OfEncrypted             = errors.New("the encrypted string is invalid base64")
-	ErrIVNotSet                          = errors.New("initialization vector must be set to use this encryption mode")
-	ErrInvalidIV                         = errors.New("initialization vector must be 128 bits")
-	ErrInvalidPKCS7Padding               = errors.New("invalid PCKS7 padding")
-	ErrMissingAPIResource                = errors.New("one or more API resources are not installed on the API server")
-	ErrMissingAPIResourceInvalidTemplate = errors.New(
-		"one or more API resources are not installed on the API server which could have led to the templating error",
-	)
-	ErrProtectNotEnabled  = errors.New("the protect template function is not enabled in this mode")
-	ErrNewLinesNotAllowed = errors.New("new lines are not allowed in the string passed to the toLiteral function")
-	ErrInvalidContextType = errors.New(
+	ErrAESKeyNotSet          = errors.New("AESKey must be set to use this encryption mode")
+	ErrInvalidAESKey         = errors.New("the AES key is invalid")
+	ErrInvalidB64OfEncrypted = errors.New("the encrypted string is invalid base64")
+	ErrIVNotSet              = errors.New("initialization vector must be set to use this encryption mode")
+	ErrInvalidIV             = errors.New("initialization vector must be 128 bits")
+	ErrInvalidPKCS7Padding   = errors.New("invalid PCKS7 padding")
+	ErrMissingAPIResource    = errors.New("one or more API resources are not installed on the API server")
+	ErrProtectNotEnabled     = errors.New("the protect template function is not enabled in this mode")
+	ErrNewLinesNotAllowed    = errors.New("new lines are not allowed in the string passed to the toLiteral function")
+	ErrInvalidContextType    = errors.New(
 		"the input context must be a struct, with either string fields or map[string]string fields",
 	)
+	ErrMissingNamespace    = errors.New("the lookup of a single namespaced resource must have a namespace specified")
+	ErrRestrictedNamespace = errors.New("the namespace argument is restricted")
+	ErrInvalidInput        = errors.New("the input is invalid")
+	ErrCacheDisabled       = client.ErrCacheDisabled
 )
 
-// Config is a struct containing configuration for the API. Some are required.
+// Config is a struct containing configuration for the API.
 //
 // - AdditionalIndentation sets the number of additional spaces to be added to the input number
 // to the indent method. This is useful in situations when the indentation should be relative
 // to a logical starting point in a YAML file.
 //
 // - DisabledFunctions is a slice of default template function names that should be disabled.
-// - KubeAPIResourceList sets the cache for the Kubernetes API resources. If this is
-// set, template processing will not try to rediscover the Kubernetes API resources
-// needed for dynamic client/ GVK lookups.
-//
-// - EncryptionConfig is the configuration for template encryption/decryption functionality.
-//
-// - InitializationVector is the initialization vector (IV) used in the AES-CBC encryption/decryption. Note that it must
-// be equal to the AES block size which is always 128 bits (16 bytes). This value must be random but does not need to be
-// private. Its purpose is to make the same plaintext value, when encrypted with the same AES key, appear unique. When
-// performing decryption, the IV must be the same as it was for the encryption of the data. Note that all values
-// encrypted in the template will use this same IV, which means that duplicate plaintext values that are encrypted will
-// yield the same encrypted value in the template.
-//
-// - LookupNamespace is the namespace to restrict "lookup" template functions (e.g. fromConfigMap)
-// to. If this is not set (i.e. an empty string), then all namespaces can be used.
-//
-// - ClusterScopedAllowList is a list of cluster-scoped object identifiers (group, kind, name) which
-// are allowed to be used in "lookup" calls even when LookupNamespace is set. A wildcard value `*`
-// may be used in any or all of the fields. The default behavior when LookupNamespace is set is to
-// deny all cluster-scoped lookups.
 //
 // - StartDelim customizes the start delimiter used to distinguish a template action. This defaults
 // to "{{". If StopDelim is set, this must also be set.
@@ -88,16 +71,37 @@ var (
 // - InputIsYAML can be set to true to indicate that the input to the template is already in YAML format and thus does
 // not need to be converted from JSON to YAML before template processing occurs. This should be set to true when
 // passing raw YAML directly to the template resolver.
+//
+// - MissingAPIResourceCacheTTL can be set if you want to temporarily cache an API resource is missing to avoid
+// duplicate API queries when a CRD is missing. By default, this will not be cached. Note that this only affects
+// when caching is enabled.
 type Config struct {
-	AdditionalIndentation uint
-	DisabledFunctions     []string
-	EncryptionConfig
-	KubeAPIResourceList    []*metav1.APIResourceList
-	LookupNamespace        string
+	AdditionalIndentation      uint
+	DisabledFunctions          []string
+	StartDelim                 string
+	StopDelim                  string
+	InputIsYAML                bool
+	MissingAPIResourceCacheTTL time.Duration
+}
+
+// ResolveOptions is a struct containing configuration for calling ResolveTemplates.
+//
+// - ClusterScopedAllowList is a list of cluster-scoped object identifiers (group, kind, name) which
+// are allowed to be used in "lookup" calls even when LookupNamespace is set. A wildcard value `*`
+// may be used in any or all of the fields. The default behavior when LookupNamespace is set is to
+// deny all cluster-scoped lookups.
+//
+// - EncryptionConfig is the configuration for template encryption/decryption functionality.
+//
+// - LookupNamespace is the namespace to restrict "lookup" template functions (e.g. fromConfigMap)
+// to. If this is not set (i.e. an empty string), then all namespaces can be used.
+//
+// - Watcher is the Kubernetes object that includes the templates. This is only used when caching is enabled.
+type ResolveOptions struct {
 	ClusterScopedAllowList []ClusterScopedObjectIdentifier
-	StartDelim             string
-	StopDelim              string
-	InputIsYAML            bool
+	EncryptionConfig
+	LookupNamespace string
+	Watcher         *client.ObjectIdentifier
 }
 
 type ClusterScopedObjectIdentifier struct {
@@ -140,35 +144,28 @@ type EncryptionConfig struct {
 // TemplateResolver is the API for processing templates. It's better to use the NewResolver function
 // instead of instantiating this directly so that configuration defaults and validation are applied.
 type TemplateResolver struct {
-	kubeClient *kubernetes.Interface
-	kubeConfig *rest.Config
-	config     Config
-	// Denotes if the lookup template function encountered an API resource that is not installed on
-	// the Kubernetes API server.
-	missingAPIResource bool
-	referencedObjects  []client.ObjectIdentifier
+	config Config
+	// Used when caching is disabled.
+	dynamicClient *dynamic.DynamicClient
+	kubeConfig    *rest.Config
+	// Used when instantiated with NewResolverWithCaching. This will create watches and the cache will get
+	// automatically updated.
+	dynamicWatcher client.DynamicWatcher
+	// If caching is disabled, this will act as a temporary cache for objects during the execution of the
+	// ResolveTemplate call.
+	tempCallCache client.ObjectCache
 }
 
 type TemplateResult struct {
-	ResolvedJSON      []byte
-	ReferencedObjects []client.ObjectIdentifier
+	ResolvedJSON []byte
 }
 
 // NewResolver creates a new TemplateResolver instance, which is the API for processing templates.
 //
-// - kubeClient is the Kubernetes client to be used for the template lookup functions.
+// - kubeConfig is the rest.Config instance used to create Kubernetes clients for template processing.
 //
-// - config is the Config instance for configuration for template processing.
-func NewResolver(kubeClient *kubernetes.Interface, kubeConfig *rest.Config, config Config) (*TemplateResolver, error) {
-	if kubeClient == nil {
-		return nil, fmt.Errorf("kubeClient must be a non-nil value")
-	}
-
-	err := validateEncryptionConfig(config.EncryptionConfig)
-	if err != nil {
-		return nil, fmt.Errorf("error validating EncryptionConfig: %w", err)
-	}
-
+// - config is the Config instance for configuring optional values for template processing.
+func NewResolver(kubeConfig *rest.Config, config Config) (*TemplateResolver, error) {
 	if (config.StartDelim != "" && config.StopDelim == "") || (config.StartDelim == "" && config.StopDelim != "") {
 		return nil, fmt.Errorf("the configurations StartDelim and StopDelim cannot be set independently")
 	}
@@ -181,11 +178,73 @@ func NewResolver(kubeClient *kubernetes.Interface, kubeConfig *rest.Config, conf
 
 	klog.V(2).Infof("Using the delimiters of %s and %s", config.StartDelim, config.StopDelim)
 
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	tempCallCache := client.NewObjectCache(
+		// Set the missing API resource cache TTL in this mode because the cache just lives for the ResolveTemplate
+		// execution and duplicate queries when a CRD is missing is not necessary.
+		discoveryClient, client.ObjectCacheOptions{MissingAPIResourceCacheTTL: time.Minute},
+	)
+
+	dynamicClient, err := dynamic.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	return &TemplateResolver{
-		kubeClient: kubeClient,
-		kubeConfig: kubeConfig,
-		config:     config,
+		config: config, dynamicClient: dynamicClient, kubeConfig: kubeConfig, tempCallCache: tempCallCache,
 	}, nil
+}
+
+// NewResolverWithCaching creates a new caching TemplateResolver instance, which is the API for processing templates.
+//
+// The caching works by adding watches to the objects and list queries used in the templates. A controller-runtime
+// Channel is also returned to trigger reconciles on the watched object provided in ResolveTemplate when a watched
+// object is added, updated, or removed.
+//
+//   - ctx should be a cancelable context that should be canceled when you want the background goroutines involving
+//     caching to be stopped.
+//
+//   - kubeConfig is the rest.Config instance used to create Kubernetes clients for template processing.
+//
+//   - config is the Config instance for configuring optional values for template processing.
+func NewResolverWithCaching(
+	ctx context.Context, kubeConfig *rest.Config, config Config,
+) (
+	*TemplateResolver, *source.Channel, error,
+) {
+	resolver, err := NewResolver(kubeConfig, config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	reconciler, channel := client.NewControllerRuntimeSource()
+	dynamicWatcher, err := client.New(
+		kubeConfig,
+		reconciler,
+		&client.Options{
+			DisableInitialReconcile: true,
+			EnableCache:             true,
+			ObjectCacheOptions: client.ObjectCacheOptions{
+				MissingAPIResourceCacheTTL: config.MissingAPIResourceCacheTTL,
+			},
+		},
+	)
+
+	go func() {
+		err = dynamicWatcher.Start(ctx)
+	}()
+
+	<-dynamicWatcher.Started()
+
+	resolver.dynamicWatcher = dynamicWatcher
+	resolver.dynamicClient = nil
+	resolver.tempCallCache = nil
+
+	return resolver, channel, err
 }
 
 // HasTemplate performs a simple check for the template start delimiter or the "$ocm_encrypted" prefix
@@ -279,29 +338,6 @@ func getValidContext(context interface{}) (ctx interface{}, _ error) {
 	return context, nil
 }
 
-// SetKubeAPIResourceList overrides the KubeAPIResourceList value on the TemplateResolver
-// configuration.
-func (t *TemplateResolver) SetKubeAPIResourceList(resourceList []*metav1.APIResourceList) {
-	t.config.KubeAPIResourceList = resourceList
-}
-
-// SetEncryptionConfig accepts an EncryptionConfig struct and validates it to ensure that if
-// encryption and/or decryption are enabled that the AES Key and Initialization Vector are valid. If
-// validation passes, SetEncryptionConfig updates the EncryptionConfig in the TemplateResolver
-// configuration. Otherwise, an error is returned and the configuration is unchanged.
-func (t *TemplateResolver) SetEncryptionConfig(encryptionConfig EncryptionConfig) error {
-	klog.V(2).Info("Setting EncryptionConfig for templates")
-
-	err := validateEncryptionConfig(encryptionConfig)
-	if err != nil {
-		return err
-	}
-
-	t.config.EncryptionConfig = encryptionConfig
-
-	return nil
-}
-
 // SetInputIsYAML sets the resolver's inputIsYAML configuration value.
 func (t *TemplateResolver) SetInputIsYAML(inputIsYAML bool) {
 	klog.V(2).Infof("Setting InputIsYAML to %t", inputIsYAML)
@@ -363,17 +399,35 @@ func validateEncryptionConfig(encryptionConfig EncryptionConfig) error {
 //
 // ResolveTemplate will process any template strings in the map and return the processed map. The
 // ErrMissingAPIResource is returned when one or more "lookup" calls referenced an API resource
-// which isn't installed on the Kubernetes API server. In this case, the resolved template is still
-// returned. ErrMissingAPIResourceInvalidTemplate can also be returned in this case but it also means the template
-// failed to resolve, so the resolved template will not be returned.
-func (t *TemplateResolver) ResolveTemplate(tmplRaw []byte, context interface{}) (TemplateResult, error) {
+// which isn't installed on the Kubernetes API server.
+//
+// The input options contains options for template resolution. The options.Watcher field is an ObjectIdentifier that is
+// used in caching mode and the controller-runtime integration. Set this to nil when not in caching mode. When in
+// caching mode, watches are automatically garbage collected when a new call to ResolveTemplate no longer specifies an
+// object or list query it used to.
+//
+// This method is only concurrency safe when caching is enabled. When caching is disabled, a local cache of objects
+// is stored just for the ResolveTemplate execution to avoid duplicate API queries. If running this method concurrently
+// with caching disabled, you may get some items from the temporary cache while others will be from API queries.
+func (t *TemplateResolver) ResolveTemplate(
+	tmplRaw []byte, context interface{}, options *ResolveOptions,
+) (TemplateResult, error) {
 	klog.V(2).Infof("ResolveTemplate for: %v", string(tmplRaw))
 
-	// Always reset this value on each ResolveTemplate call.
-	t.missingAPIResource = false
-	t.referencedObjects = []client.ObjectIdentifier{}
+	if options == nil {
+		options = &ResolveOptions{}
+	}
 
 	var resolvedResult TemplateResult
+
+	err := validateEncryptionConfig(options.EncryptionConfig)
+	if err != nil {
+		return resolvedResult, fmt.Errorf("error validating EncryptionConfig: %w", err)
+	}
+
+	if t.dynamicWatcher != nil && options.Watcher == nil {
+		return resolvedResult, fmt.Errorf("%w: watcherObject cannot be nil if caching is enabled", ErrInvalidInput)
+	}
 
 	ctx, err := getValidContext(context)
 	if err != nil {
@@ -382,12 +436,12 @@ func (t *TemplateResolver) ResolveTemplate(tmplRaw []byte, context interface{}) 
 
 	// Build Map of supported template functions
 	funcMap := template.FuncMap{
-		"copyConfigMapData": t.copyConfigMapData,
-		"copySecretData":    t.copySecretData,
-		"fromSecret":        t.fromSecret,
-		"fromConfigMap":     t.fromConfigMap,
-		"fromClusterClaim":  t.fromClusterClaim,
-		"lookup":            t.lookup,
+		"copyConfigMapData": t.copyConfigMapDataHelper(options),
+		"copySecretData":    t.copySecretDataHelper(options),
+		"fromSecret":        t.fromSecretHelper(options),
+		"fromConfigMap":     t.fromConfigMapHelper(options),
+		"fromClusterClaim":  t.fromClusterClaimHelper(options),
+		"lookup":            t.lookupHelper(options),
 		"base64enc":         base64encode,
 		"base64dec":         base64decode,
 		"autoindent":        autoindent,
@@ -403,10 +457,10 @@ func (t *TemplateResolver) ResolveTemplate(tmplRaw []byte, context interface{}) 
 		funcMap[fname] = getSprigFunc(fname)
 	}
 
-	if t.config.EncryptionEnabled {
-		funcMap["fromSecret"] = t.fromSecretProtected
-		funcMap["protect"] = t.protect
-		funcMap["copySecretData"] = t.copySecretDataProtected
+	if options.EncryptionEnabled {
+		funcMap["fromSecret"] = t.fromSecretProtectedHelper(options)
+		funcMap["protect"] = t.protectHelper(options)
+		funcMap["copySecretData"] = t.copySecretDataProtectedHelper(options)
 	} else {
 		// In other encryption modes, return a readable error if the protect template function is accidentally used.
 		funcMap["protect"] = func(s string) (string, error) { return "", ErrProtectNotEnabled }
@@ -435,8 +489,8 @@ func (t *TemplateResolver) ResolveTemplate(tmplRaw []byte, context interface{}) 
 
 	klog.V(2).Infof("Initial template str to resolve : %v ", templateStr)
 
-	if t.config.DecryptionEnabled {
-		templateStr, err = t.processEncryptedStrs(templateStr)
+	if options.DecryptionEnabled {
+		templateStr, err = t.processEncryptedStrs(options, templateStr)
 		if err != nil {
 			return resolvedResult, err
 		}
@@ -463,17 +517,38 @@ func (t *TemplateResolver) ResolveTemplate(tmplRaw []byte, context interface{}) 
 
 	var buf bytes.Buffer
 
-	err = tmpl.Execute(&buf, ctx)
+	// If the dynamic watcher caching style is disabled, clear the cache after resolving the template.
+	if t.tempCallCache != nil {
+		defer t.tempCallCache.Clear()
+	}
 
-	resolvedResult.ReferencedObjects = t.referencedObjects
+	if t.dynamicWatcher != nil {
+		watcher := *options.Watcher
+
+		err := t.dynamicWatcher.StartQueryBatch(watcher)
+		if err != nil {
+			if errors.Is(err, client.ErrQueryBatchInProgress) {
+				return resolvedResult, fmt.Errorf(
+					"ResolveTemplate cannot be called with the same watchedObject in parallel: %w", err,
+				)
+			}
+
+			return resolvedResult, err
+		}
+
+		defer func() {
+			err := t.dynamicWatcher.EndQueryBatch(watcher)
+			if err != nil && !errors.Is(err, client.ErrQueryBatchNotStarted) {
+				klog.Errorf("failed to end the query batch for %s: %v", watcher, err)
+			}
+		}()
+	}
+
+	err = tmpl.Execute(&buf, ctx)
 
 	if err != nil {
 		tmplRawStr := string(tmplRaw)
 		klog.Errorf("error resolving the template %v,\n template str %v,\n error: %v", tmplRawStr, templateStr, err)
-
-		if t.missingAPIResource {
-			return resolvedResult, fmt.Errorf("%w: %w: %v", ErrMissingAPIResourceInvalidTemplate, err, tmplRawStr)
-		}
 
 		return resolvedResult, fmt.Errorf("failed to resolve the template %v: %w", tmplRawStr, err)
 	}
@@ -487,13 +562,18 @@ func (t *TemplateResolver) ResolveTemplate(tmplRaw []byte, context interface{}) 
 		return resolvedResult, fmt.Errorf("failed to convert the resolved template to JSON: %w", err)
 	}
 
-	if t.missingAPIResource {
-		return resolvedResult, ErrMissingAPIResource
-	}
-
 	resolvedResult.ResolvedJSON = resolvedTemplateBytes
 
 	return resolvedResult, nil
+}
+
+// UncacheWatcher will clear the watcher from the cache and remove all associated API watches.
+func (t *TemplateResolver) UncacheWatcher(watcher client.ObjectIdentifier) error {
+	if t.dynamicWatcher == nil {
+		return ErrCacheDisabled
+	}
+
+	return t.dynamicWatcher.RemoveWatcher(watcher)
 }
 
 //nolint:wsl
@@ -636,17 +716,4 @@ func toLiteral(a string) (string, error) {
 	}
 
 	return a, nil
-}
-
-func (t *TemplateResolver) addToReferencedObjects(apiversion string, kind string, namespace string, name string) {
-	gvk := schema.FromAPIVersionAndKind(apiversion, kind)
-
-	objID := client.ObjectIdentifier{
-		Group:     gvk.Group,
-		Version:   gvk.Version,
-		Kind:      kind,
-		Namespace: namespace,
-		Name:      name,
-	}
-	t.referencedObjects = append(t.referencedObjects, objID)
 }

--- a/pkg/templates/templates_suite_test.go
+++ b/pkg/templates/templates_suite_test.go
@@ -19,7 +19,6 @@ const testNs = "testns"
 
 var (
 	k8sConfig       *rest.Config
-	k8sClient       kubernetes.Interface
 	testEnv         *envtest.Environment
 	ctx             context.Context
 	cancel          context.CancelFunc
@@ -56,7 +55,7 @@ func setUp() {
 		panic(err.Error())
 	}
 
-	k8sClient, err = kubernetes.NewForConfig(k8sConfig)
+	k8sClient, err := kubernetes.NewForConfig(k8sConfig)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -271,8 +271,8 @@ data4: '{{ (lookup "v1" "Secret" "testns" "does-not-exist").data.key }}'
 	}
 
 	// One for the transformer and one for the lookup and one for the failed lookup
-	if resolver.dynamicWatcher.GetWatchCount() != 3 {
-		t.Fatalf("Expected a watch count of 3 but got: %d", resolver.dynamicWatcher.GetWatchCount())
+	if resolver.GetWatchCount() != 3 {
+		t.Fatalf("Expected a watch count of 3 but got: %d", resolver.GetWatchCount())
 	}
 
 	cachedObjects, err := resolver.dynamicWatcher.ListWatchedFromCache(watcher)
@@ -381,8 +381,8 @@ func TestResolveTemplateWithCachingListQuery(t *testing.T) {
 		t.Fatalf("Unexpected template: %s", string(result.ResolvedJSON))
 	}
 
-	if resolver.dynamicWatcher.GetWatchCount() != 1 {
-		t.Fatalf("Expected a watch count of 1 but got: %d", resolver.dynamicWatcher.GetWatchCount())
+	if resolver.GetWatchCount() != 1 {
+		t.Fatalf("Expected a watch count of 1 but got: %d", resolver.GetWatchCount())
 	}
 
 	cachedObjects, err := resolver.dynamicWatcher.ListWatchedFromCache(watcher)


### PR DESCRIPTION
See each commit for changes.

The default caching mode is one that caches objects for the duration of the ResolveTemplate execution. This mode is not completely concurrency safe.

The advanced caching mode is concurrency safe and utilizes watches to update the cache in background goroutines.

Relates:
https://issues.redhat.com/browse/ACM-7398