### PR TITLE
Allow control of when the cache and API watches are cleaned up

### DIFF
--- a/experimental/client.go
+++ b/experimental/client.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/klog"
 	"sigs.k8s.io/yaml"
 
-	"github.com/stolostron/go-template-utils/v3/pkg/templates"
+	"github.com/stolostron/go-template-utils/v4/pkg/templates"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stolostron/go-template-utils/v3
+module github.com/stolostron/go-template-utils/v4
 
 go 1.20
 


### PR DESCRIPTION
This is needed by the Policy Propagator since it processes its policy-templates array entries one at a time and we don't want to clean up stale API watches and cache entries until those are all processed.

The second commit bumps the version to v4.