### PR TITLE
Move CLI directory; Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,17 @@ Additionally, the following custom functions are supported:
   field contains a JSON string that you want to literally replace the template
   with and have it treated as the underlying JSON type.
 
-## CLI (Experimental)
+## `template-resolver` CLI (Experimental)
 
-The client CLI tool is used to help during policy development involving
+The `template-resolver` CLI tool is used to help during policy development involving
 templates. Note that the generated output is only partially validated for
 syntax.
+
+### Building the binary
+
+```bash
+go install ./experimental/template-resolver
+```
 
 ### Managed Cluster Templates Example
 
@@ -109,7 +115,7 @@ spec:
             {{- end }}
 EOF
 
-go run experimental/client.go policy-example.yaml
+template-resolver policy-example.yaml
 ```
 
 The output should be:
@@ -182,7 +188,7 @@ spec:
             {{- end }}
 EOF
 
-go run experimental/client.go -hub-kubeconfig ~/.kube/config -cluster-name local-cluster policy-example.yaml
+template-resolver -hub-kubeconfig ~/.kube/config -cluster-name local-cluster policy-example.yaml
 ```
 
 The output should be:

--- a/README.md
+++ b/README.md
@@ -30,40 +30,28 @@ long as the input to
 can be marshaled to YAML, any of the
 [text/template](https://pkg.go.dev/text/template) package features can be used.
 
+A subset of [Sprig](https://masterminds.github.io/sprig/) functions is imported 
+into the resolver, listed in [`pkg/templates/sprig_wrapper.go`](pkg/templates/sprig_wrapper.go#L14).
+
 Additionally, the following custom functions are supported:
 
-- `atoi` parses an input string and returns an integer like the
-  [Atoi](https://pkg.go.dev/strconv#Atoi) function. For example,
-  `{{ "6" | atoi }}`.
-- `autoindent` will automatically indent the input string based on the leading
-  spaces. For example, `{{ "Templating\nrocks!" | autoindent }}`.
-- `base64enc` decodes the input Base64 string to its decoded form. For example,
-  `{{ "VGVtcGxhdGVzIHJvY2shCg==" | base64dec }}`.
-- `base64enc` encodes an input string in the Base64 format. For example,
-  `{{ "Templating rocks!" | base64enc }}`.
-- `indent` will indent the input string by specified amount. For example,
-  `{{ "Templating\nrocks!" | indent 4 }}`.
-- `fromClusterClaim` returns the value of a specific `ClusterClaim`. For
-  example, `{{ fromClusterClaim "name" }}`.
-- `fromConfigMap` returns the value of a key inside a `ConfigMap`. For example,
-  `{{ fromConfigMap "namespace" "config-map-name" "key" }}`.
-- `fromSecret` returns the value of a key inside a `Secret`. For example,
-  `{{ fromSecret "namespace" "secret-name" "key" }}`. If the `EncryptionMode` is
-  set to `EncryptionEnabled`, this will return an encrypted value.
-- `lookup` is a generic lookup function for any Kubernetes object. For example,
-  `{{ (lookup "v1" "Secret" "namespace" "name").Data.key }}`.
-- `protect` is a function that encrypts any string using AES-CBC.
-- `toBool` - parses an input boolean string converts it to a boolean but also
-  removes any quotes around the map value. For example,
-  `key: "{{ "true" | toBool }}"` => `key: true`.
-- `toInt` parses an input string and returns an integer but also removes any
-  quotes around the map value. For example, `key: "{{ "6" | toInt }}"` =>
-  `key: 6`.
-- `toLiteral` removes any quotes around the template string after it is
-  processed. For example, `key: "{{ "[10.10.10.10, 1.1.1.1]" | toLiteral }}` =>
-  `key: [10.10.10.10, 1.1.1.1]`. A good use-case for this is when a `ConfigMap`
-  field contains a JSON string that you want to literally replace the template
-  with and have it treated as the underlying JSON type.
+Function | Description | Example
+--- | --- | ---
+`atoi` | Parses an input string and returns an integer like the [Atoi](https://pkg.go.dev/strconv#Atoi) function. | `{{ "6" \| atoi }}`
+`autoindent` | Automatically indents the input string based on the leading spaces. | `{{ "Templating\nrocks!" \| autoindent }}`
+`base64enc` | Decodes the input Base64 string to its decoded form. |`{{ "VGVtcGxhdGVzIHJvY2shCg==" \| base64dec }}`
+`base64enc` | Encodes an input string in the Base64 format. | `{{ "Templating rocks!" \| base64enc }}`
+`indent` | Indents the input string by the specified amount. | `{{ "Templating\nrocks!" \| indent 4 }}`
+`fromClusterClaim` | Returns the value of a specific `ClusterClaim`. | `{{ fromClusterClaim "name" }}`
+`fromConfigMap` | Returns the value of a key inside a `ConfigMap`. | `{{ fromConfigMap "namespace" "config-map-name" "key" }}`
+`copyConfigMapData` | Returns the `data` contents of the specified `ConfigMap` | `{{ copyConfigMapData "namespace" "config-map-name" }}`
+`fromSecret` | Returns the value of a key inside a `Secret`. If the `EncryptionMode` is set to `EncryptionEnabled`, this will return an encrypted value. | `{{ fromSecret "namespace" "secret-name" "key" }}`
+`copySecretData` | Returns the `data` contents of the specified `Secret`. If the `EncryptionMode` is set to `EncryptionEnabled`, this will return an encrypted value. | `{{ copySecretData "namespace" "secret-name" }}`
+`lookup` | Generic lookup function for any Kubernetes object. | `{{ (lookup "v1" "Secret" "namespace" "name").data.key }}`
+`protect` | Encrypts any string using AES-CBC. | `{{ "super-secret" \| protect }}`
+`toBool` | Parses an input boolean string converts it to a boolean but also removes any quotes around the map value. | `key: "{{ "true" \| toBool }}"` => `key: true`
+`toInt` | Parses an input string and returns an integer but also removes anyquotes around the map value. |  `key: "{{ "6" \| toInt }}"` => `key: 6`
+`toLiteral` | Removes any quotes around the template string after it is processed. | `key: "{{ "[10.10.10.10, 1.1.1.1]" \| toLiteral }}` => `key: [10.10.10.10, 1.1.1.1]`
 
 ## `template-resolver` CLI (Experimental)
 

--- a/experimental/template-resolver/client.go
+++ b/experimental/template-resolver/client.go
@@ -22,10 +22,19 @@ import (
 )
 
 func main() {
-	klog.InitFlags(nil)
-
 	var hubKubeConfigPath, clusterName string
 
+	flag.Usage = func() {
+		fmt.Fprintln(os.Stderr, `Usage: template-resolver [OPTIONS] [path to YAML]
+  -cluster-name string
+    	the cluster name to use as .ManagedClusterName when resolving hub templates
+  -hub-kubeconfig string
+    	the input kubeconfig to also resolve hub templates
+  -v value
+    	number for the log level verbosity`)
+	}
+
+	klog.InitFlags(nil)
 	flag.StringVar(&hubKubeConfigPath, "hub-kubeconfig", "", "the input kubeconfig to also resolve hub templates")
 	flag.StringVar(
 		&clusterName, "cluster-name", "", "the cluster name to use as .ManagedClusterName when resolving hub templates",
@@ -345,5 +354,5 @@ func processTemplate(yamlFile, hubKubeConfigPath, clusterName string) {
 	}
 
 	//nolint: forbidigo
-	fmt.Println(string(resolvedYAML))
+	fmt.Print(string(resolvedYAML))
 }


### PR DESCRIPTION
- Allows `go install` to be run with the resulting binary named "template-resolver" (rather than "experimental")
- Adds positional argument usage if the `--help` flag is passed
- Adds manual help output to remove extra klog arguments
- Removes extra trailing newline from output
- Adds missing functions and converts function list to a table

(Regarding the CLI, I played around with adding a `go.mod`, but the `replace` directives prevented the resulting `go install` from working since it wasn't the main module.)