### PR TITLE
Add resolve option to error on missing keys

### DIFF
--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -725,6 +725,13 @@ func TestResolveTemplateErrors(t *testing.T) {
 				ErrInvalidInput,
 			),
 		},
+		"error_on_missing_key": {
+			inputTmpl: `foo: '{{ (lookup "v1" "ConfigMap" "testns" "nonexist-cm").data }}'`,
+			resolveOptions: ResolveOptions{
+				ErrorOnMissingKey: true,
+			},
+			expectedErr: ErrMissingKey,
+		},
 	}
 
 	for testName, test := range testcases {


### PR DESCRIPTION
By default, the template engine uses `<no value>` when a key is missing from a lookup, and it does not return an error. That behavior can make it less obvious when something is going wrong in a template.