### PR TITLE
Return if the templates contain sensitive data

### DIFF
--- a/pkg/templates/clusterconfig_funcs.go
+++ b/pkg/templates/clusterconfig_funcs.go
@@ -22,7 +22,7 @@ func (t *TemplateResolver) fromClusterClaim(options *ResolveOptions, claimName s
 		return "", errors.New("a claim name must be provided")
 	}
 
-	clusterClaim, err := t.getOrList(options, clusterClaimAPIVersion, "ClusterClaim", "", claimName)
+	clusterClaim, err := t.getOrList(options, nil, clusterClaimAPIVersion, "ClusterClaim", "", claimName)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/templates/encryption.go
+++ b/pkg/templates/encryption.go
@@ -159,7 +159,11 @@ func pkcs7Unpad(paddedValue []byte) ([]byte, error) {
 // processEncryptedStrs replaces all encrypted strings with the decrypted values. Each decryption is handled
 // concurrently and the concurrency limit is controlled by t.config.DecryptionConcurrency. If a decryption fails,
 // the rest of the decryption is halted and an error is returned.
-func (t *TemplateResolver) processEncryptedStrs(options *ResolveOptions, templateStr string) (string, error) {
+func (t *TemplateResolver) processEncryptedStrs(
+	options *ResolveOptions,
+	templateResult *TemplateResult,
+	templateStr string,
+) (string, error) {
 	// This catching any encrypted string in the format of $ocm_encrypted:<base64 of the encrypted value>.
 	re := regexp.MustCompile(regexp.QuoteMeta(protectedPrefix) + "([a-zA-Z0-9+/=]+)")
 	// Each submatch will have index 0 be the whole match and index 1 as the base64 of the encrypted value.
@@ -168,6 +172,8 @@ func (t *TemplateResolver) processEncryptedStrs(options *ResolveOptions, templat
 	if len(submatches) == 0 {
 		return templateStr, nil
 	}
+
+	templateResult.HasSensitiveData = true
 
 	var numWorkers int
 

--- a/pkg/templates/generic_lookup_func_test.go
+++ b/pkg/templates/generic_lookup_func_test.go
@@ -61,8 +61,11 @@ func TestLookup(t *testing.T) {
 			t.Fatalf(err.Error())
 		}
 
+		templateResult := &TemplateResult{}
+
 		val, err := resolver.lookup(
 			&ResolveOptions{LookupNamespace: test.lookupNamespace},
+			templateResult,
 			test.inputAPIVersion,
 			test.inputKind,
 			test.inputNs,
@@ -84,6 +87,10 @@ func TestLookup(t *testing.T) {
 		if test.expectedExists {
 			if len(val) == 0 {
 				t.Fatal("An object was expected but not returned")
+			}
+
+			if test.inputKind == "Secret" && !templateResult.HasSensitiveData {
+				t.Fatalf("expected HasSensitiveData to be set to true")
 			}
 		} else if len(val) != 0 {
 			t.Fatal("An object was unexpected but one was returned")
@@ -216,6 +223,7 @@ func TestLookupWithLabels(t *testing.T) {
 		//nolint:gocritic
 		val, err := resolver.lookup(
 			&ResolveOptions{LookupNamespace: test.lookupNamespace},
+			nil,
 			test.inputAPIVersion,
 			test.inputKind,
 			test.inputNs,
@@ -356,11 +364,14 @@ func TestLookupClusterScoped(t *testing.T) {
 			t.Fatalf(err.Error())
 		}
 
+		templateResult := &TemplateResult{}
+
 		val, err := resolver.lookup(
 			&ResolveOptions{
 				LookupNamespace:        test.lookupNamespace,
 				ClusterScopedAllowList: test.allowlist,
 			},
+			templateResult,
 			test.inputAPIVersion,
 			test.inputKind,
 			test.inputNs,
@@ -385,6 +396,10 @@ func TestLookupClusterScoped(t *testing.T) {
 			}
 		} else if len(val) != 0 {
 			t.Fatal("An object was unexpected but one was returned")
+		}
+
+		if templateResult.HasSensitiveData {
+			t.Fatalf("expected HasSensitiveData to be set to false")
 		}
 	}
 }


### PR DESCRIPTION
If the template handled a secret or decrypted data in the template, the TemplateResult now has a field of HasSensitiveData set to true.

This is required as part of automatically determining if it's safe to record a diff in the config-policy-controller.

Relates:
https://issues.redhat.com/browse/ACM-11421