### PR TITLE
Add getNodesWithExactRoles and hasNodesWithExactRoles template functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Function | Description | Example
 `toBool` | Parses an input boolean string converts it to a boolean but also removes any quotes around the map value. | `key: "{{ "true" \| toBool }}"` => `key: true`
 `toInt` | Parses an input string and returns an integer but also removes anyquotes around the map value. |  `key: "{{ "6" \| toInt }}"` => `key: 6`
 `toLiteral` | Removes any quotes around the template string after it is processed. | `key: "{{ "[10.10.10.10, 1.1.1.1]" \| toLiteral }}` => `key: [10.10.10.10, 1.1.1.1]`
+`getNodesWithExactRoles` | Returns a list of nodes with only the role(s) specified, ignores nodes that have any additional roles except "*node-role.kubernetes.io/worker*" role. | `{{ (getNodesWithExactRoles "infra").items }}`
+`hasNodesWithExactRoles` | Returns `true` if the cluster contains node(s) with only the role(s) specified, ignores nodes that have any additional roles except "*node-role.kubernetes.io/worker*" role. | `key: {{ (hasNodesWithExactRoles "infra") }}` => `key: true`
 
 ## `template-resolver` CLI (Beta)
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/spf13/cast v1.6.0
 	github.com/stolostron/kubernetes-dependency-watches v0.8.1
-	golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.5
 	k8s.io/apimachinery v0.29.5
@@ -45,6 +44,7 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
+	golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.20.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -498,22 +498,24 @@ func (t *TemplateResolver) ResolveTemplate(
 
 	// Build Map of supported template functions
 	funcMap := template.FuncMap{
-		"copyConfigMapData": t.copyConfigMapDataHelper(options),
-		"copySecretData":    t.copySecretDataHelper(options, &resolvedResult),
-		"fromSecret":        t.fromSecretHelper(options, &resolvedResult),
-		"fromConfigMap":     t.fromConfigMapHelper(options),
-		"fromClusterClaim":  t.fromClusterClaimHelper(options),
-		"lookup":            t.lookupHelper(options, &resolvedResult),
-		"base64enc":         base64encode,
-		"base64dec":         base64decode,
-		"b64enc":            base64encode, // Link the Sprig name to our function
-		"b64dec":            base64decode, // Link the Sprig name to our function
-		"autoindent":        autoindent,
-		"indent":            t.indent,
-		"atoi":              atoi,
-		"toInt":             toInt,
-		"toBool":            toBool,
-		"toLiteral":         toLiteral,
+		"copyConfigMapData":      t.copyConfigMapDataHelper(options),
+		"copySecretData":         t.copySecretDataHelper(options, &resolvedResult),
+		"fromSecret":             t.fromSecretHelper(options, &resolvedResult),
+		"fromConfigMap":          t.fromConfigMapHelper(options),
+		"fromClusterClaim":       t.fromClusterClaimHelper(options),
+		"getNodesWithExactRoles": t.getNodesWithExactRolesHelper(options, &resolvedResult),
+		"hasNodesWithExactRoles": t.hasNodesWithExactRolesHelper(options),
+		"lookup":                 t.lookupHelper(options, &resolvedResult),
+		"base64enc":              base64encode,
+		"base64dec":              base64decode,
+		"b64enc":                 base64encode, // Link the Sprig name to our function
+		"b64dec":                 base64decode, // Link the Sprig name to our function
+		"autoindent":             autoindent,
+		"indent":                 t.indent,
+		"atoi":                   atoi,
+		"toInt":                  toInt,
+		"toBool":                 toBool,
+		"toLiteral":              toLiteral,
 	}
 
 	// Add all the functions from sprig we will support

--- a/pkg/templates/templates_suite_test.go
+++ b/pkg/templates/templates_suite_test.go
@@ -185,6 +185,63 @@ func setUp() {
 		panic(err.Error())
 	}
 
+	// sample Nodes to test Infra node lookups
+	nodea1 := corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-infra1",
+			Labels: map[string]string{
+				"node-role.kubernetes.io/infra": "",
+			},
+		},
+	}
+
+	nodea2 := corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-infra2",
+			Labels: map[string]string{
+				"node-role.kubernetes.io/infra":  "",
+				"node-role.kubernetes.io/worker": "",
+			},
+		},
+	}
+
+	nodeb := corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-storage",
+			Labels: map[string]string{
+				"node-role.kubernetes.io/infra":   "",
+				"node-role.kubernetes.io/storage": "",
+			},
+		},
+	}
+
+	_, err = k8sClient.CoreV1().Nodes().Create(ctx, &nodea1, metav1.CreateOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+
+	_, err = k8sClient.CoreV1().Nodes().Create(ctx, &nodea2, metav1.CreateOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+
+	_, err = k8sClient.CoreV1().Nodes().Create(ctx, &nodeb, metav1.CreateOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+
 	k8sDynClient, err := dynamic.NewForConfig(k8sConfig)
 	if err != nil {
 		panic(err.Error())


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-12342

Adds two template functions to reduce complexity in Policies around identifying nodes by role, specifically useful for Infra nodes.

getNodesWithExactRoles - only returns nodes that have label "node-role.kubernetes.io/NAME"  and optionally "node-role.kubernetes.io/worker".  Nodes which have "node-role.kubernetes.io/NAME"  and any other role label are ignored.  Can pass multiple NAME parameters.

hasNodesWithExactRoles - returns true if getNodesWithRole returns more than zero nodes  for the specified role name(s) parameter.