### PR TITLE
Allow full control of query batches

### DIFF
--- a/cmd/template-resolver/client.go
+++ b/cmd/template-resolver/client.go
@@ -9,7 +9,7 @@ import (
 
 	"k8s.io/klog"
 
-	templateresolver "github.com/stolostron/go-template-utils/v5/cmd/template-resolver/utils"
+	templateresolver "github.com/stolostron/go-template-utils/v6/cmd/template-resolver/utils"
 )
 
 func main() {

--- a/cmd/template-resolver/utils/templateResolver.go
+++ b/cmd/template-resolver/utils/templateResolver.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/stolostron/go-template-utils/v5/pkg/templates"
+	"github.com/stolostron/go-template-utils/v6/pkg/templates"
 )
 
 // HandleFile takes a file path and returns the resulting byte array. If an

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stolostron/go-template-utils/v5
+module github.com/stolostron/go-template-utils/v6
 
 go 1.21
 


### PR DESCRIPTION
Rather than the partial control of `DisableAutoCacheCleanUp` and `NewResolverWithDynamicWatcher`, this is simplified to either the batch is fully managed in the `ResolveTemplate` call or the caller completely controls the batch. 

This simplifies the API for most use cases.

Note that since this is a break change, the version is bumped.

Relates:
https://issues.redhat.com/browse/ACM-12790