### PR TITLE
Add ObjectNamespace and ObjectName arguments

### DIFF
--- a/cmd/template-resolver/client_test.go
+++ b/cmd/template-resolver/client_test.go
@@ -59,7 +59,10 @@ func cliTest(testName string) func(t *testing.T) {
 			hubNS = "policies"
 		}
 
-		resolvedYAML, err := utils.ProcessTemplate(inputBytes, kcPath, clusterName, hubNS)
+		objNamespace := "my-obj-namespace"
+		objName := "my-obj-name"
+
+		resolvedYAML, err := utils.ProcessTemplate(inputBytes, kcPath, clusterName, hubNS, objNamespace, objName)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/template-resolver/testdata/test_custom-sa_hub/input.yaml
+++ b/cmd/template-resolver/testdata/test_custom-sa_hub/input.yaml
@@ -28,3 +28,4 @@ spec:
                   namespace: default
                   labels:
                     random-name: '{{hub (lookup "v1" "Namespace" "" "random").metadata.name hub}}'
+                    name: '{{ .ObjectName }}'

--- a/cmd/template-resolver/testdata/test_custom-sa_hub/output.yaml
+++ b/cmd/template-resolver/testdata/test_custom-sa_hub/output.yaml
@@ -23,6 +23,7 @@ spec:
                 kind: ConfigMap
                 metadata:
                   labels:
+                    name: my-obj-name
                     random-name: random
                   name: random
                   namespace: default

--- a/cmd/template-resolver/testdata/test_obj_variable_config/input.yaml
+++ b/cmd/template-resolver/testdata/test_obj_variable_config/input.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: obj-ns-name
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    include:
+      - my-obj-namespace
+  object-templates:
+    - complianceType: musthave
+      objectSelector:
+        matchExpressions:
+          - key: my-obj
+            operator: Exists
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          namespace: '{{ .ObjectNamespace }}'
+          name: '{{ .ObjectName }}'
+          labels:
+            case13: passed
+            name: '{{ .ObjectName }}'
+            namespace: "{{ .ObjectNamespace }}"

--- a/cmd/template-resolver/testdata/test_obj_variable_config/output.yaml
+++ b/cmd/template-resolver/testdata/test_obj_variable_config/output.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: obj-ns-name
+spec:
+  namespaceSelector:
+    include:
+      - my-obj-namespace
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          labels:
+            case13: passed
+            name: my-obj-name
+            namespace: my-obj-namespace
+          name: my-obj-name
+          namespace: my-obj-namespace
+      objectSelector:
+        matchExpressions:
+          - key: my-obj
+            operator: Exists
+  remediationAction: enforce

--- a/cmd/template-resolver/testdata/test_obj_variable_operator/input.yaml
+++ b/cmd/template-resolver/testdata/test_obj_variable_operator/input.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
+metadata:
+  name: some-operator
+spec:
+  complianceType: musthave
+  remediationAction: enforce
+  severity: high
+  subscription:
+    name: my-favorite-operator
+    namespace: '{{ .ObjectNamespace }}'

--- a/cmd/template-resolver/testdata/test_obj_variable_operator/output.yaml
+++ b/cmd/template-resolver/testdata/test_obj_variable_operator/output.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
+metadata:
+  name: some-operator
+spec:
+  complianceType: musthave
+  remediationAction: enforce
+  severity: high
+  subscription:
+    name: my-favorite-operator
+    namespace: my-obj-namespace

--- a/cmd/template-resolver/testdata/test_object-templates-raw/input.yaml
+++ b/cmd/template-resolver/testdata/test_object-templates-raw/input.yaml
@@ -10,5 +10,6 @@ object-templates-raw: |
         namespace: {{ .metadata.namespace }}
         labels:
           ford.com/model: Mustang
+          name: {{ $.ObjectName }}
   {{- end }}
   {{- end }}

--- a/cmd/template-resolver/testdata/test_object-templates-raw/output.yaml
+++ b/cmd/template-resolver/testdata/test_object-templates-raw/output.yaml
@@ -6,5 +6,6 @@ object-templates:
       metadata:
         labels:
           ford.com/model: Mustang
+          name: my-obj-name
         name: cool-car
         namespace: default

--- a/cmd/template-resolver/utils/resolver_client.go
+++ b/cmd/template-resolver/utils/resolver_client.go
@@ -12,6 +12,8 @@ type TemplateResolver struct {
 	hubKubeConfigPath string
 	clusterName       string
 	hubNamespace      string
+	objNamespace      string
+	objName           string
 }
 
 func (t *TemplateResolver) GetCmd() *cobra.Command {
@@ -46,6 +48,19 @@ func (t *TemplateResolver) GetCmd() *cobra.Command {
 		"hub-namespace",
 		"",
 		"the namespace on the hub to restrict namespaced lookups to when resolving hub templates",
+	)
+	templateResolverCmd.Flags().StringVar(
+		&t.objNamespace,
+		"object-namespace",
+		"",
+		"the object namespace to use for the .ObjectNamespace template variable when policy uses namespaceSelector",
+	)
+	templateResolverCmd.Flags().StringVar(
+		&t.objName,
+		"object-name",
+		"",
+		"the object namespace to use for the .ObjectName template variable "+
+			"when policy uses namespaceSelector or objectSelector",
 	)
 
 	return templateResolverCmd
@@ -85,7 +100,8 @@ func (t *TemplateResolver) resolveTemplates(cmd *cobra.Command, args []string) e
 		return fmt.Errorf("error handling YAML file input: %w", err)
 	}
 
-	resolvedYAML, err := ProcessTemplate(yamlBytes, t.hubKubeConfigPath, t.clusterName, t.hubNamespace)
+	resolvedYAML, err := ProcessTemplate(yamlBytes, t.hubKubeConfigPath,
+		t.clusterName, t.hubNamespace, t.objNamespace, t.objName)
 	if err != nil {
 		cmd.Printf("error processing templates: %s\n", err.Error())
 

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -128,6 +128,11 @@ type ResolveOptions struct {
 	Watcher         *client.ObjectIdentifier
 }
 
+type TemplateContext struct {
+	ObjectNamespace string
+	ObjectName      string
+}
+
 type ClusterScopedObjectIdentifier struct {
 	Group string
 	Kind  string


### PR DESCRIPTION
As a template-resolver user, I'd like a way to supply "ObjectNamespace" and "ObjectName" template variable values as CLI arguments to template-resolver like I can with the "--cluster-name" argument. This allows me to resolve templates locally that leverage these new template variables.

Ref: https://issues.redhat.com/browse/ACM-15971