### PR TITLE
Include the full YAML of the objects it uses in funcs

### DIFF
--- a/cmd/template-resolver/testdata/test_config-policy-directly/input.yaml
+++ b/cmd/template-resolver/testdata/test_config-policy-directly/input.yaml
@@ -15,3 +15,4 @@ spec:
           namespace: '{{ (lookup "v1" "ConfigMap" "default" "cool-car").metadata.namespace }}'
           labels:
             ford.com/model: '{{ fromConfigMap "default" "cool-car" "model" }}'
+

--- a/cmd/template-resolver/testdata/test_config-policy-directly/save_resources.yaml
+++ b/cmd/template-resolver/testdata/test_config-policy-directly/save_resources.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+data:
+    model: Shelby Mustang
+kind: ConfigMap
+metadata:
+    name: cool-car
+    namespace: default

--- a/cmd/template-resolver/testdata/test_config-policy-directly_hub/save_hub_resources.yaml
+++ b/cmd/template-resolver/testdata/test_config-policy-directly_hub/save_hub_resources.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+data:
+    model: Subaru Baja
+kind: ConfigMap
+metadata:
+    name: coolest-car
+    namespace: policies

--- a/cmd/template-resolver/testdata/test_custom-sa_hub/save_hub_resources.yaml
+++ b/cmd/template-resolver/testdata/test_custom-sa_hub/save_hub_resources.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: random
+

--- a/cmd/template-resolver/testdata/test_label-configmaps/save_resources.yaml
+++ b/cmd/template-resolver/testdata/test_label-configmaps/save_resources.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+data:
+    model: Shelby Mustang
+kind: ConfigMap
+metadata:
+    name: cool-car
+    namespace: default
+---
+apiVersion: v1
+data:
+    model: Pinto
+kind: ConfigMap
+metadata:
+    name: not-cool-car
+    namespace: default
+---
+apiVersion: v1
+data:
+    namespace: foobar
+kind: ConfigMap
+metadata:
+    name: operator-config
+    namespace: default

--- a/cmd/template-resolver/testdata/test_label-configmaps_hub/save_resources.yaml
+++ b/cmd/template-resolver/testdata/test_label-configmaps_hub/save_resources.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+data:
+    model: Shelby Mustang
+kind: ConfigMap
+metadata:
+    name: cool-car
+    namespace: default
+---
+apiVersion: v1
+data:
+    model: Pinto
+kind: ConfigMap
+metadata:
+    name: not-cool-car
+    namespace: default
+---
+apiVersion: v1
+data:
+    namespace: foobar
+kind: ConfigMap
+metadata:
+    name: operator-config
+    namespace: default

--- a/cmd/template-resolver/testdata/test_object-templates-raw/save_resources.yaml
+++ b/cmd/template-resolver/testdata/test_object-templates-raw/save_resources.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+data:
+    model: Shelby Mustang
+kind: ConfigMap
+metadata:
+    name: cool-car
+    namespace: default
+---
+apiVersion: v1
+data:
+    model: Pinto
+kind: ConfigMap
+metadata:
+    name: not-cool-car
+    namespace: default
+---
+apiVersion: v1
+data:
+    namespace: foobar
+kind: ConfigMap
+metadata:
+    name: operator-config
+    namespace: default

--- a/cmd/template-resolver/testdata/test_operator-policy-directly/save_resources.yaml
+++ b/cmd/template-resolver/testdata/test_operator-policy-directly/save_resources.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+data:
+    namespace: foobar
+kind: ConfigMap
+metadata:
+    name: operator-config
+    namespace: default

--- a/cmd/template-resolver/testdata/test_operator-policy/save_resources.yaml
+++ b/cmd/template-resolver/testdata/test_operator-policy/save_resources.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+data:
+    namespace: foobar
+kind: ConfigMap
+metadata:
+    name: operator-config
+    namespace: default

--- a/cmd/template-resolver/testdata/test_operator-policy_hub/save_resources.yaml
+++ b/cmd/template-resolver/testdata/test_operator-policy_hub/save_resources.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+data:
+    namespace: foobar
+kind: ConfigMap
+metadata:
+    name: operator-config
+    namespace: default

--- a/cmd/template-resolver/utils/resolver_client.go
+++ b/cmd/template-resolver/utils/resolver_client.go
@@ -14,6 +14,9 @@ type TemplateResolver struct {
 	hubNamespace      string
 	objNamespace      string
 	objName           string
+	saveResources     string
+	// saveHubResources Output doesn't include "ManagedClusters" resources,
+	saveHubResources string
 }
 
 func (t *TemplateResolver) GetCmd() *cobra.Command {
@@ -63,6 +66,22 @@ func (t *TemplateResolver) GetCmd() *cobra.Command {
 			"when policy uses namespaceSelector or objectSelector",
 	)
 
+	templateResolverCmd.Flags().StringVar(
+		&t.saveResources,
+		"save-resources",
+		"s",
+		"the path to save the output containing resources used. "+
+			"This output can be used as input resources for the dry-run CLI or for local environment testing.",
+	)
+
+	templateResolverCmd.Flags().StringVar(
+		&t.saveHubResources,
+		"save-hub-resources",
+		"s",
+		"the path to save the output containing resources used in the hub cluster. "+
+			"This output can be used as input resources for the dry-run CLI or for local environment testing.",
+	)
+
 	return templateResolverCmd
 }
 
@@ -101,7 +120,7 @@ func (t *TemplateResolver) resolveTemplates(cmd *cobra.Command, args []string) e
 	}
 
 	resolvedYAML, err := ProcessTemplate(yamlBytes, t.hubKubeConfigPath,
-		t.clusterName, t.hubNamespace, t.objNamespace, t.objName)
+		t.clusterName, t.hubNamespace, t.objNamespace, t.objName, t.saveResources, t.saveHubResources)
 	if err != nil {
 		cmd.Printf("error processing templates: %s\n", err.Error())
 

--- a/pkg/templates/generic_lookup_func.go
+++ b/pkg/templates/generic_lookup_func.go
@@ -216,6 +216,11 @@ func (t *TemplateResolver) getOrList(
 			templateResult.HasSensitiveData = true
 		}
 
+		// Cache a not found result
+		for _, i := range resultUnstructuredList.Items {
+			t.appendUsedResources(i)
+		}
+
 		return resultUnstructuredList.UnstructuredContent(), nil
 	}
 
@@ -232,6 +237,9 @@ func (t *TemplateResolver) getOrList(
 
 		return nil, err
 	}
+
+	// Cache a not found result
+	t.appendUsedResources(*resultUnstructured)
 
 	if templateResult != nil && kind == "Secret" {
 		templateResult.HasSensitiveData = true


### PR DESCRIPTION
The template resolver should output the full YAML of objects used in lookups, fromConfig, fromSecret, etc., allowing users to easily modify them for tests using dry-run.
Ref: https://issues.redhat.com/browse/ACM-17214