### PR TITLE
Add `skipObject` custom function

### DIFF
--- a/cmd/template-resolver/testdata/test_skipobject/input.yaml
+++ b/cmd/template-resolver/testdata/test_skipobject/input.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: skipobject-name
+spec:
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          labels:
+            cluster: "{{ skipObject }}"
+          namespace: my-obj-namespace
+      objectSelector:
+        matchExpressions:
+          - key: my-obj
+            operator: Exists
+  remediationAction: enforce

--- a/cmd/template-resolver/testdata/test_skipobject/output.yaml
+++ b/cmd/template-resolver/testdata/test_skipobject/output.yaml
@@ -1,0 +1,7 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: skipobject-name
+spec:
+  object-templates: []
+  remediationAction: enforce

--- a/cmd/template-resolver/testdata/test_skipobject_multi_arg/error.txt
+++ b/cmd/template-resolver/testdata/test_skipobject_multi_arg/error.txt
@@ -1,0 +1,1 @@
+template: tmpl:7:19: executing "tmpl" at <skipObject true false>: error calling skipObject: expected one optional boolean argument but received 2 arguments

--- a/cmd/template-resolver/testdata/test_skipobject_multi_arg/input.yaml
+++ b/cmd/template-resolver/testdata/test_skipobject_multi_arg/input.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: skipobject-name
+spec:
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          labels:
+            cluster: "{{ skipObject true false }}"
+          namespace: my-obj-namespace
+      objectSelector:
+        matchExpressions:
+          - key: my-obj
+            operator: Exists
+  remediationAction: enforce

--- a/cmd/template-resolver/testdata/test_skipobject_non_bool/error.txt
+++ b/cmd/template-resolver/testdata/test_skipobject_non_bool/error.txt
@@ -1,0 +1,1 @@
+template: tmpl:7:19: executing "tmpl" at <skipObject "not a bool">: error calling skipObject: expected boolean but received 'not a bool'

--- a/cmd/template-resolver/testdata/test_skipobject_non_bool/input.yaml
+++ b/cmd/template-resolver/testdata/test_skipobject_non_bool/input.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: skipobject-name
+spec:
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          labels:
+            cluster: '{{ skipObject "not a bool" }}'
+          namespace: my-obj-namespace
+      objectSelector:
+        matchExpressions:
+          - key: my-obj
+            operator: Exists
+  remediationAction: enforce

--- a/cmd/template-resolver/utils/resolver_utils.go
+++ b/cmd/template-resolver/utils/resolver_utils.go
@@ -436,10 +436,25 @@ func processObjectTemplates(
 		fieldName := fmt.Sprintf("object-templates[%v]", i)
 		skipObject := false
 		resolveOptions.CustomFunctions = template.FuncMap{
-			"skipObject": func() string {
-				skipObject = true
+			"skipObject": func(skips ...any) (empty string, err error) {
+				switch len(skips) {
+				case 0:
+					skipObject = true
+				case 1:
+					if !skipObject {
+						if skip, ok := skips[0].(bool); ok {
+							skipObject = skip
+						} else {
+							err = fmt.Errorf(
+								"expected boolean but received '%v'", skips[0])
+						}
+					}
+				default:
+					err = fmt.Errorf(
+						"expected one optional boolean argument but received %d arguments", len(skips))
+				}
 
-				return ""
+				return
 			},
 		}
 

--- a/testdata/crds.yaml
+++ b/testdata/crds.yaml
@@ -22,7 +22,6 @@ spec:
            2. clusterset.k8s.io, it contains an identifier that relates the cluster
               to the ClusterSet in which it belongs.
 
-
           ClusterClaims created on a managed cluster will be collected and saved into
           the status of the corresponding ManagedCluster on hub.
         properties:
@@ -103,16 +102,13 @@ spec:
           of a managed cluster. ManagedCluster is a cluster-scoped resource. The name
           is the cluster UID.
 
-
           The cluster join process is a double opt-in process. See the following join process steps:
-
 
           1. The agent on the managed cluster creates a CSR on the hub with the cluster UID and agent name.
           2. The agent on the managed cluster creates a ManagedCluster on the hub.
           3. The cluster admin on the hub cluster approves the CSR for the UID and agent name of the ManagedCluster.
           4. The cluster admin sets the spec.acceptClient of the ManagedCluster to true.
           5. The cluster admin on the managed cluster creates a credential of the kubeconfig for the hub cluster.
-
 
           After the hub cluster creates the cluster namespace, the klusterlet agent on the ManagedCluster pushes
           the credential to the hub cluster to use against the kube-apiserver of the ManagedCluster.
@@ -162,9 +158,8 @@ spec:
                   ManagedClusterClientConfigs represents a list of the apiserver address of the managed cluster.
                   If it is empty, the managed cluster has no accessible address for the hub to connect with it.
                 items:
-                  description: |-
-                    ClientConfig represents the apiserver address of the managed cluster.
-                    TODO include credential to connect to managed cluster kube-apiserver
+                  description: ClientConfig represents the apiserver address of the
+                    managed cluster.
                   properties:
                     caBundle:
                       description: |-
@@ -176,6 +171,8 @@ spec:
                       description: URL is the URL of apiserver endpoint of the managed
                         cluster.
                       type: string
+                  required:
+                  - url
                   type: object
                 type: array
               taints:
@@ -218,8 +215,11 @@ spec:
                   required:
                   - effect
                   - key
+                  - timeAdded
                   type: object
                 type: array
+            required:
+            - hubAcceptsClient
             type: object
           status:
             description: Status represents the current status of joined managed cluster
@@ -274,16 +274,8 @@ spec:
                 description: Conditions contains the different condition statuses
                   for this managed cluster.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -324,12 +316,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string


### PR DESCRIPTION
By returning a template string rather than skipping the template, this will allow passing to tools like `dryrun` to perform proper handling.

ref: https://issues.redhat.com/browse/ACM-19739

This PR will need to be followed up with one that adds arguments for ACM 2.14 for changes in:
- https://github.com/open-cluster-management-io/config-policy-controller/pull/354