### PR TITLE
Expand context kinds allowed

### DIFF
--- a/pkg/templates/sprig_wrapper_test.go
+++ b/pkg/templates/sprig_wrapper_test.go
@@ -299,8 +299,9 @@ func TestGetSprigFunc(t *testing.T) {
 			`{{ upper "foo bar" }}`,
 			"FOO BAR",
 		},
+		// Pass to sortAlpha because the order returned isn't guaranteed
 		"values": {
-			`{{ values (dict "key1" "value1" "key2" "value2") }}`,
+			`{{ values (dict "key1" "value1" "key2" "value2") | sortAlpha }}`,
 			"[value1 value2]",
 		},
 	}


### PR DESCRIPTION
With the `.Object` variable, Kubernetes objects could have a variety of kinds. Expand the context check to allow these kinds, avoiding pointers, channels, and functions that could disrupt or cause unexpected results in templates.

ref: https://issues.redhat.com/browse/ACM-20863