### PR TITLE
fix: Resolve panic when manifest has an `int`

### DIFF
--- a/cmd/template-resolver/client_test.go
+++ b/cmd/template-resolver/client_test.go
@@ -107,8 +107,14 @@ func cliTest(testName string) func(t *testing.T) {
 			// If an error file is provided, overwrite the
 			// expected and resolved with the error contents
 			expectedBytes = errorBytes
+
 			errMatch := regexp.MustCompile("template: tmpl:[0-9]+:[0-9]+: .*")
 			resolvedYAML = errMatch.Find([]byte(err.Error()))
+
+			// If nothing is matched, use the entire error
+			if len(resolvedYAML) == 0 {
+				resolvedYAML = []byte(err.Error())
+			}
 		}
 
 		// Compare the saved resources. Use hubCluster resources

--- a/cmd/template-resolver/testdata/test_invalid-objdef-missing/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-objdef-missing/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates entry was provided at index 0: objectDefinition key not found

--- a/cmd/template-resolver/testdata/test_invalid-objdef-missing/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-objdef-missing/input.yaml
@@ -1,0 +1,6 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-object-definition
+spec:
+  policy-templates: [{}]

--- a/cmd/template-resolver/testdata/test_invalid-objdef/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-objdef/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates entry was provided at index 0: .objectDefinition accessor error: 0 is of the type float64, expected map[string]interface{}

--- a/cmd/template-resolver/testdata/test_invalid-objdef/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-objdef/input.yaml
@@ -1,0 +1,7 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-object-definition
+spec:
+  policy-templates:
+    - objectDefinition: 0

--- a/cmd/template-resolver/testdata/test_invalid-policy-spec-missing/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-spec-missing/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates array was provided: spec.policy-templates keys not found

--- a/cmd/template-resolver/testdata/test_invalid-policy-spec-missing/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-spec-missing/input.yaml
@@ -1,0 +1,4 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: no-spec

--- a/cmd/template-resolver/testdata/test_invalid-policy-spec/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-spec/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates array was provided: .spec.policy-templates accessor error: [] is of the type []interface {}, expected map[string]interface{}

--- a/cmd/template-resolver/testdata/test_invalid-policy-spec/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-spec/input.yaml
@@ -1,0 +1,5 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-spec
+spec: []

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates-bad-entry/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates-bad-entry/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates entry was provided at index 0: could not parse to map[string]interface{}

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates-bad-entry/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates-bad-entry/input.yaml
@@ -1,0 +1,7 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-policy-template-entry
+spec:
+  policy-templates:
+    - whee!!!

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates-missing/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates-missing/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates array was provided: spec.policy-templates keys not found

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates-missing/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates-missing/input.yaml
@@ -1,0 +1,5 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: missing-policy-templates
+spec: {}

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates array was provided: .spec.policy-templates accessor error: map[] is of the type map[string]interface {}, expected []interface{}

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates/input.yaml
@@ -1,0 +1,6 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-policy-templates
+spec:
+  policy-templates: {}

--- a/cmd/template-resolver/testdata/test_policy-policy-templates-int/input.yaml
+++ b/cmd/template-resolver/testdata/test_policy-policy-templates-int/input.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-spec
+spec:
+  policy-templates:
+  - objectDefinition:
+      int-map: 100

--- a/cmd/template-resolver/testdata/test_policy-policy-templates-int/output.yaml
+++ b/cmd/template-resolver/testdata/test_policy-policy-templates-int/output.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-spec
+spec:
+  policy-templates:
+    - objectDefinition:
+        int-map: 100

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	k8s.io/client-go v0.31.9
 	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.19.7
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -64,5 +65,4 @@ require (
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.3 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )


### PR DESCRIPTION
The `unstructured` package made the decision to not support `int` types, but that's exactly what our YAML marshaler uses. Changing to type assertions avoids the panic.

ref: https://issues.redhat.com/browse/ACM-18816