### PR TITLE
[release-2.13] fix: Resolve panic when manifest has an `int`

### DIFF
--- a/cmd/template-resolver/client_test.go
+++ b/cmd/template-resolver/client_test.go
@@ -96,8 +96,14 @@ func cliTest(testName string) func(t *testing.T) {
 			// If an error file is provided, overwrite the
 			// expected and resolved with the error contents
 			expectedBytes = errorBytes
+
 			errMatch := regexp.MustCompile("template: tmpl:[0-9]+:[0-9]+: .*")
 			resolvedYAML = errMatch.Find([]byte(err.Error()))
+
+			// If nothing is matched, use the entire error
+			if len(resolvedYAML) == 0 {
+				resolvedYAML = []byte(err.Error())
+			}
 		}
 
 		// Compare the saved resources. Use hubCluster resources

--- a/cmd/template-resolver/testdata/test_invalid-objdef-missing/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-objdef-missing/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates entry was provided at index 0: objectDefinition key not found

--- a/cmd/template-resolver/testdata/test_invalid-objdef-missing/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-objdef-missing/input.yaml
@@ -1,0 +1,6 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-object-definition
+spec:
+  policy-templates: [{}]

--- a/cmd/template-resolver/testdata/test_invalid-objdef/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-objdef/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates entry was provided at index 0: .objectDefinition accessor error: 0 is of the type float64, expected map[string]interface{}

--- a/cmd/template-resolver/testdata/test_invalid-objdef/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-objdef/input.yaml
@@ -1,0 +1,7 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-object-definition
+spec:
+  policy-templates:
+    - objectDefinition: 0

--- a/cmd/template-resolver/testdata/test_invalid-policy-spec-missing/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-spec-missing/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates array was provided: spec.policy-templates keys not found

--- a/cmd/template-resolver/testdata/test_invalid-policy-spec-missing/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-spec-missing/input.yaml
@@ -1,0 +1,4 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: no-spec

--- a/cmd/template-resolver/testdata/test_invalid-policy-spec/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-spec/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates array was provided: .spec.policy-templates accessor error: [] is of the type []interface {}, expected map[string]interface{}

--- a/cmd/template-resolver/testdata/test_invalid-policy-spec/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-spec/input.yaml
@@ -1,0 +1,5 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-spec
+spec: []

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates-bad-entry/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates-bad-entry/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates entry was provided at index 0: could not parse to map[string]interface{}

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates-bad-entry/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates-bad-entry/input.yaml
@@ -1,0 +1,7 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-policy-template-entry
+spec:
+  policy-templates:
+    - whee!!!

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates-missing/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates-missing/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates array was provided: spec.policy-templates keys not found

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates-missing/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates-missing/input.yaml
@@ -1,0 +1,5 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: missing-policy-templates
+spec: {}

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates array was provided: .spec.policy-templates accessor error: map[] is of the type map[string]interface {}, expected []interface{}

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates/input.yaml
@@ -1,0 +1,6 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-policy-templates
+spec:
+  policy-templates: {}

--- a/cmd/template-resolver/testdata/test_policy-policy-templates-int/input.yaml
+++ b/cmd/template-resolver/testdata/test_policy-policy-templates-int/input.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-spec
+spec:
+  policy-templates:
+  - objectDefinition:
+      int-map: 100

--- a/cmd/template-resolver/testdata/test_policy-policy-templates-int/output.yaml
+++ b/cmd/template-resolver/testdata/test_policy-policy-templates-int/output.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-spec
+spec:
+  policy-templates:
+    - objectDefinition:
+        int-map: 100

--- a/cmd/template-resolver/utils/resolver_utils.go
+++ b/cmd/template-resolver/utils/resolver_utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
+	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/stolostron/go-template-utils/v6/pkg/templates"
 )
@@ -78,7 +80,7 @@ func ProcessTemplate(yamlBytes []byte, hubKubeConfigPath, clusterName, hubNS,
 ) ([]byte, error) {
 	policy := unstructured.Unstructured{}
 
-	err := yaml.Unmarshal(yamlBytes, &policy.Object)
+	err := k8syaml.Unmarshal(yamlBytes, &policy.Object)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse input to YAML: %w", err)
 	}
@@ -275,20 +277,26 @@ func processPolicyTemplate(
 	resolver *templates.TemplateResolver,
 	tempCtx templates.TemplateContext,
 ) error {
-	policyTemplates, _, err := unstructured.NestedSlice(policy.Object, "spec", "policy-templates")
+	policyTemplates, found, err := unstructured.NestedSlice(policy.Object, "spec", "policy-templates")
 	if err != nil {
 		return fmt.Errorf("invalid policy-templates array was provided: %w", err)
+	} else if !found {
+		return errors.New("invalid policy-templates array was provided: spec.policy-templates keys not found")
 	}
 
 	for i := range policyTemplates {
-		policyTemplate, ok := policyTemplates[i].(map[string]interface{})
+		policyTemplate, ok := policyTemplates[i].(map[string]any)
 		if !ok {
-			return fmt.Errorf("invalid policy-templates entry was provided: %w", err)
+			return fmt.Errorf("invalid policy-templates entry was provided at index %d: "+
+				"could not parse to map[string]interface{}", i)
 		}
 
-		objectDefinition, ok := policyTemplate["objectDefinition"].(map[string]interface{})
-		if !ok {
-			return fmt.Errorf("invalid policy-templates entry was provided: %w", err)
+		objectDefinition, found, err := unstructured.NestedMap(policyTemplate, "objectDefinition")
+		if err != nil {
+			return fmt.Errorf("invalid policy-templates entry was provided at index %d: %w", i, err)
+		} else if !found {
+			return fmt.Errorf("invalid policy-templates entry was provided at index %d: "+
+				"objectDefinition key not found", i)
 		}
 
 		templateObj := unstructured.Unstructured{Object: objectDefinition}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	k8s.io/client-go v0.31.0
 	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.19.0
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -65,5 +66,4 @@ require (
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/testdata/crds.yaml
+++ b/testdata/crds.yaml
@@ -215,11 +215,8 @@ spec:
                   required:
                   - effect
                   - key
-                  - timeAdded
                   type: object
                 type: array
-            required:
-            - hubAcceptsClient
             type: object
           status:
             description: Status represents the current status of joined managed cluster


### PR DESCRIPTION
Manual cherry-pick:
- #203

ref: https://issues.redhat.com/browse/ACM-18816
Signed-off-by: Dale Haiducek <19750917+dhaiducek@users.noreply.github.com>