### PR TITLE
[release-2.12] fix: Resolve panic when manifest has an `int`

### DIFF
--- a/cmd/template-resolver/client_test.go
+++ b/cmd/template-resolver/client_test.go
@@ -84,8 +84,14 @@ func cliTest(testName string) func(t *testing.T) {
 			// If an error file is provided, overwrite the
 			// expected and resolved with the error contents
 			expectedBytes = errorBytes
+
 			errMatch := regexp.MustCompile("template: tmpl:[0-9]+:[0-9]+: .*")
 			resolvedYAML = errMatch.Find([]byte(err.Error()))
+
+			// If nothing is matched, use the entire error
+			if len(resolvedYAML) == 0 {
+				resolvedYAML = []byte(err.Error())
+			}
 		}
 
 		if !bytes.Equal(expectedBytes, resolvedYAML) {

--- a/cmd/template-resolver/testdata/test_invalid-objdef-missing/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-objdef-missing/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates entry was provided at index 0: objectDefinition key not found

--- a/cmd/template-resolver/testdata/test_invalid-objdef-missing/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-objdef-missing/input.yaml
@@ -1,0 +1,6 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-object-definition
+spec:
+  policy-templates: [{}]

--- a/cmd/template-resolver/testdata/test_invalid-objdef/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-objdef/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates entry was provided at index 0: .objectDefinition accessor error: 0 is of the type float64, expected map[string]interface{}

--- a/cmd/template-resolver/testdata/test_invalid-objdef/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-objdef/input.yaml
@@ -1,0 +1,7 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-object-definition
+spec:
+  policy-templates:
+    - objectDefinition: 0

--- a/cmd/template-resolver/testdata/test_invalid-policy-spec-missing/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-spec-missing/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates array was provided: spec.policy-templates keys not found

--- a/cmd/template-resolver/testdata/test_invalid-policy-spec-missing/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-spec-missing/input.yaml
@@ -1,0 +1,4 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: no-spec

--- a/cmd/template-resolver/testdata/test_invalid-policy-spec/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-spec/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates array was provided: .spec.policy-templates accessor error: [] is of the type []interface {}, expected map[string]interface{}

--- a/cmd/template-resolver/testdata/test_invalid-policy-spec/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-spec/input.yaml
@@ -1,0 +1,5 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-spec
+spec: []

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates-bad-entry/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates-bad-entry/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates entry was provided at index 0: could not parse to map[string]interface{}

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates-bad-entry/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates-bad-entry/input.yaml
@@ -1,0 +1,7 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-policy-template-entry
+spec:
+  policy-templates:
+    - whee!!!

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates-missing/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates-missing/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates array was provided: spec.policy-templates keys not found

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates-missing/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates-missing/input.yaml
@@ -1,0 +1,5 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: missing-policy-templates
+spec: {}

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates/error.txt
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates/error.txt
@@ -1,0 +1,1 @@
+invalid policy-templates array was provided: .spec.policy-templates accessor error: map[] is of the type map[string]interface {}, expected []interface{}

--- a/cmd/template-resolver/testdata/test_invalid-policy-templates/input.yaml
+++ b/cmd/template-resolver/testdata/test_invalid-policy-templates/input.yaml
@@ -1,0 +1,6 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-policy-templates
+spec:
+  policy-templates: {}

--- a/cmd/template-resolver/testdata/test_policy-policy-templates-int/input.yaml
+++ b/cmd/template-resolver/testdata/test_policy-policy-templates-int/input.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-spec
+spec:
+  policy-templates:
+  - objectDefinition:
+      int-map: 100

--- a/cmd/template-resolver/testdata/test_policy-policy-templates-int/output.yaml
+++ b/cmd/template-resolver/testdata/test_policy-policy-templates-int/output.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: invalid-spec
+spec:
+  policy-templates:
+    - objectDefinition:
+        int-map: 100

--- a/cmd/template-resolver/utils/resolver_utils.go
+++ b/cmd/template-resolver/utils/resolver_utils.go
@@ -4,16 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 
-	"gopkg.in/yaml.v3"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
+	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/stolostron/go-template-utils/v6/pkg/templates"
 )
@@ -74,7 +75,7 @@ func HandleFile(yamlFile string) ([]byte, error) {
 func ProcessTemplate(yamlBytes []byte, hubKubeConfigPath, clusterName, hubNS string) ([]byte, error) {
 	policy := unstructured.Unstructured{}
 
-	err := yaml.Unmarshal(yamlBytes, &policy.Object)
+	err := k8syaml.Unmarshal(yamlBytes, &policy.Object)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse input to YAML: %w", err)
 	}
@@ -229,20 +230,26 @@ func processPolicyTemplate(
 	policy *unstructured.Unstructured,
 	resolver *templates.TemplateResolver,
 ) error {
-	policyTemplates, _, err := unstructured.NestedSlice(policy.Object, "spec", "policy-templates")
+	policyTemplates, found, err := unstructured.NestedSlice(policy.Object, "spec", "policy-templates")
 	if err != nil {
 		return fmt.Errorf("invalid policy-templates array was provided: %w", err)
+	} else if !found {
+		return errors.New("invalid policy-templates array was provided: spec.policy-templates keys not found")
 	}
 
 	for i := range policyTemplates {
-		policyTemplate, ok := policyTemplates[i].(map[string]interface{})
+		policyTemplate, ok := policyTemplates[i].(map[string]any)
 		if !ok {
-			return fmt.Errorf("invalid policy-templates entry was provided: %w", err)
+			return fmt.Errorf("invalid policy-templates entry was provided at index %d: "+
+				"could not parse to map[string]interface{}", i)
 		}
 
-		objectDefinition, ok := policyTemplate["objectDefinition"].(map[string]interface{})
-		if !ok {
-			return fmt.Errorf("invalid policy-templates entry was provided: %w", err)
+		objectDefinition, found, err := unstructured.NestedMap(policyTemplate, "objectDefinition")
+		if err != nil {
+			return fmt.Errorf("invalid policy-templates entry was provided at index %d: %w", i, err)
+		} else if !found {
+			return fmt.Errorf("invalid policy-templates entry was provided at index %d: "+
+				"objectDefinition key not found", i)
 		}
 
 		templateObj := unstructured.Unstructured{Object: objectDefinition}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	k8s.io/client-go v0.31.0
 	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.19.0
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -65,5 +66,4 @@ require (
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/testdata/crds.yaml
+++ b/testdata/crds.yaml
@@ -22,7 +22,6 @@ spec:
            2. clusterset.k8s.io, it contains an identifier that relates the cluster
               to the ClusterSet in which it belongs.
 
-
           ClusterClaims created on a managed cluster will be collected and saved into
           the status of the corresponding ManagedCluster on hub.
         properties:
@@ -103,16 +102,13 @@ spec:
           of a managed cluster. ManagedCluster is a cluster-scoped resource. The name
           is the cluster UID.
 
-
           The cluster join process is a double opt-in process. See the following join process steps:
-
 
           1. The agent on the managed cluster creates a CSR on the hub with the cluster UID and agent name.
           2. The agent on the managed cluster creates a ManagedCluster on the hub.
           3. The cluster admin on the hub cluster approves the CSR for the UID and agent name of the ManagedCluster.
           4. The cluster admin sets the spec.acceptClient of the ManagedCluster to true.
           5. The cluster admin on the managed cluster creates a credential of the kubeconfig for the hub cluster.
-
 
           After the hub cluster creates the cluster namespace, the klusterlet agent on the ManagedCluster pushes
           the credential to the hub cluster to use against the kube-apiserver of the ManagedCluster.
@@ -162,9 +158,8 @@ spec:
                   ManagedClusterClientConfigs represents a list of the apiserver address of the managed cluster.
                   If it is empty, the managed cluster has no accessible address for the hub to connect with it.
                 items:
-                  description: |-
-                    ClientConfig represents the apiserver address of the managed cluster.
-                    TODO include credential to connect to managed cluster kube-apiserver
+                  description: ClientConfig represents the apiserver address of the
+                    managed cluster.
                   properties:
                     caBundle:
                       description: |-
@@ -176,6 +171,8 @@ spec:
                       description: URL is the URL of apiserver endpoint of the managed
                         cluster.
                       type: string
+                  required:
+                  - url
                   type: object
                 type: array
               taints:
@@ -274,16 +271,8 @@ spec:
                 description: Conditions contains the different condition statuses
                   for this managed cluster.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -324,12 +313,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string


### PR DESCRIPTION
Manual cherry-pick:
- #203 

ref: https://issues.redhat.com/browse/ACM-18816