### PR TITLE
Allow nil interfaces in template context

### DIFF
--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -414,6 +414,9 @@ func isPrimitive(kind reflect.Kind) bool {
 
 func getValidContextHelper(value any) error {
 	f := reflect.TypeOf(value)
+	if f == nil { // nil interface value.
+		return nil
+	}
 
 	// Allow primitive types (excludes complex numbers)
 	if isPrimitive(f.Kind()) {

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -962,6 +962,16 @@ func TestResolveTemplateWithContext(t *testing.T) {
 			},
 			expectedResult: "value: world spacename",
 		},
+		"nested_empty_interface": {
+			inputTmpl: `value: '{{ .Foo.bar }} {{ .Foo.other }}'`,
+			ctx: struct{ Foo map[string]interface{} }{
+				Foo: map[string]interface{}{
+					"bar":   "hello",
+					"other": nil, // this can occur when YAML has 'null' fields
+				},
+			},
+			expectedResult: "value: hello <no value>",
+		},
 	}
 
 	for testName, test := range testcases {


### PR DESCRIPTION
It was discovered during testing that an empty interface (which could be encoded via 'null' in YAML) would cause a panic. This should be an allowed type, basically like a primitive.

Refs:
 - https://issues.redhat.com/browse/ACM-20863