### PR TITLE
feat: implement template linter in template-resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ lint:
 
 .PHONY: test
 test: envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(TESTARGS) ./...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(TESTARGS) -coverpkg=$(shell cat go.mod | head -1 | cut -d ' ' -f 2)/... ./...
 
 .PHONY: test-coverage
 test-coverage: TESTARGS = -cover -covermode=atomic -coverprofile=coverage.out

--- a/cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/config.yaml
+++ b/cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/config.yaml
@@ -1,0 +1,1 @@
+lint: true

--- a/cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/error.txt
+++ b/cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/error.txt
@@ -1,0 +1,9 @@
+Found linting issues:
+line 21: mismatchedDelimiters: unmatched opening delimiter '{{hub':
+	name: "{{hub .ManagedClusterName }"
+line 23: mismatchedDelimiters: unmatched opening delimiter '{{hub':
+	unclosed: "{{hub .ManagedClusterName }"
+line 26: mismatchedDelimiters: mismatched hub and managed cluster delimiters:
+	mixed: '{{hub .ManagedClusterName {{ lookup "v1" "Secret" "default" "" }} .Status }}'
+
+template: tmpl:19: unexpected "{" in operand

--- a/cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/input.yaml
+++ b/cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/input.yaml
@@ -1,0 +1,26 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: mismatched-delimiters-test
+spec:
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: mismatched-delimiters-config
+        spec:
+          remediationAction: enforce
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: "{{hub .ManagedClusterName }"
+                data:
+                  unclosed: "{{hub .ManagedClusterName }"
+                  wrongClose: '{{ fromConfigMap "default" "config" "value" }hub}'
+                  extraClose: "already closed }} but here's another"
+                  mixed: '{{hub .ManagedClusterName {{ lookup "v1" "Secret" "default" "" }} .Status }}'

--- a/cmd/template-resolver/testdata/test_linting_multiple_errors/config.yaml
+++ b/cmd/template-resolver/testdata/test_linting_multiple_errors/config.yaml
@@ -1,0 +1,1 @@
+lint: true

--- a/cmd/template-resolver/testdata/test_linting_multiple_errors/error.txt
+++ b/cmd/template-resolver/testdata/test_linting_multiple_errors/error.txt
@@ -1,0 +1,21 @@
+Found linting issues:
+line 4: trailingWhitespace: trailing whitespace detected:
+	name: multiple-errors-test  <<<
+line 7: trailingWhitespace: trailing whitespace detected:
+	- objectDefinition:	<<<
+line 21: unquotedTemplateValues: template value for key should be single-quoted:
+	name: {{ fromConfigMap "default" "config" "name" }}
+line 23: trailingWhitespace: trailing whitespace detected:
+	trailing: "value with trailing"   <<<
+line 24: unquotedTemplateValues: template value for key should be single-quoted:
+	unquoted: {{ fromConfigMap "default" "config" "value" }}
+line 25: mismatchedDelimiters: unmatched opening delimiter '{{':
+	unclosed: '{{ lookup "v1" "Secret" "default" "secret'
+line 26: trailingWhitespace: trailing whitespace detected:
+	rules: <<<
+line 27: unquotedTemplateValues: array item template should be single-quoted:
+	- {{ lookup "v1" "Secret" "default" "my-secret" }}
+line 28: mismatchedDelimiters: unmatched opening delimiter '{{':
+	- wrongClose: '{{ fromConfigMap "default" "config" "value" }hub}'
+
+failed to parse input to YAML: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{"fromConfigMap \"default\" \"config\" \"name\"":interface {}(nil)}

--- a/cmd/template-resolver/testdata/test_linting_multiple_errors/input.yaml
+++ b/cmd/template-resolver/testdata/test_linting_multiple_errors/input.yaml
@@ -1,0 +1,28 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: multiple-errors-test  
+spec:
+  policy-templates:
+    - objectDefinition:	
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: multiple-errors-config
+        spec:
+          remediationAction: enforce
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: {{ fromConfigMap "default" "config" "name" }}
+                data:
+                  trailing: "value with trailing"   
+                  unquoted: {{ fromConfigMap "default" "config" "value" }}
+                  unclosed: '{{ lookup "v1" "Secret" "default" "secret'
+                rules: 
+                  - {{ lookup "v1" "Secret" "default" "my-secret" }}
+                  - wrongClose: '{{ fromConfigMap "default" "config" "value" }hub}'

--- a/cmd/template-resolver/testdata/test_linting_trailing_whitespace/config.yaml
+++ b/cmd/template-resolver/testdata/test_linting_trailing_whitespace/config.yaml
@@ -1,0 +1,1 @@
+lint: true

--- a/cmd/template-resolver/testdata/test_linting_trailing_whitespace/input.yaml
+++ b/cmd/template-resolver/testdata/test_linting_trailing_whitespace/input.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: trailing-whitespace-test  
+spec:
+  policy-templates:
+    - objectDefinition:	
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: trailing-whitespace-config
+        spec:
+          remediationAction: enforce
+          severity: low
+          object-templates-raw: |
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap 
+                metadata:
+                  name: test-configmap
+                data:
+                  key: {{ fromConfigMap "default" "cool-car" "model" }}    

--- a/cmd/template-resolver/testdata/test_linting_trailing_whitespace/output.yaml
+++ b/cmd/template-resolver/testdata/test_linting_trailing_whitespace/output.yaml
@@ -1,0 +1,35 @@
+Found linting issues:
+line 4: trailingWhitespace: trailing whitespace detected:
+	name: trailing-whitespace-test  <<<
+line 7: trailingWhitespace: trailing whitespace detected:
+	- objectDefinition:	<<<
+line 19: trailingWhitespace: trailing whitespace detected:
+	kind: ConfigMap <<<
+line 23: trailingWhitespace: trailing whitespace detected:
+	key: {{ fromConfigMap "default" "cool-car" "model" }}    <<<
+line 23: unquotedTemplateValues: template value for key should be single-quoted:
+	key: {{ fromConfigMap "default" "cool-car" "model" }}
+
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: trailing-whitespace-test
+spec:
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: trailing-whitespace-config
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  key: Shelby Mustang
+                kind: ConfigMap
+                metadata:
+                  name: test-configmap
+          remediationAction: enforce
+          severity: low

--- a/cmd/template-resolver/testdata/test_linting_unquoted_values/config.yaml
+++ b/cmd/template-resolver/testdata/test_linting_unquoted_values/config.yaml
@@ -1,0 +1,1 @@
+lint: true

--- a/cmd/template-resolver/testdata/test_linting_unquoted_values/error.txt
+++ b/cmd/template-resolver/testdata/test_linting_unquoted_values/error.txt
@@ -1,0 +1,13 @@
+Found linting issues:
+line 21: unquotedTemplateValues: template value for key should be single-quoted:
+	name: {{ fromConfigMap "default" "cool-car" "model" }}
+line 23: unquotedTemplateValues: template value for key should be single-quoted:
+	unquotedKey: {{ fromConfigMap "default" "cool-car" "model" }}
+line 26: unquotedTemplateValues: array item template should be single-quoted:
+	- {{ (lookup "v1" "ConfigMap" "policies" "coolest-car").data.model }}
+line 28: unquotedTemplateValues: template value for key should be single-quoted:
+	- host: {{ fromConfigMap "default" "cool-car" "model" }}
+line 29: mismatchedDelimiters: mismatched hub and managed cluster delimiters:
+	- port: '{{hub .ManagedClusterName }}'
+
+failed to parse input to YAML: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{"fromConfigMap \"default\" \"cool-car\" \"model\"":interface {}(nil)}

--- a/cmd/template-resolver/testdata/test_linting_unquoted_values/input.yaml
+++ b/cmd/template-resolver/testdata/test_linting_unquoted_values/input.yaml
@@ -1,0 +1,29 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: unquoted-template-values-test
+spec:
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: unquoted-values-config
+        spec:
+          remediationAction: enforce
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: {{ fromConfigMap "default" "cool-car" "model" }}
+                data:
+                  unquotedKey: {{ fromConfigMap "default" "cool-car" "model" }}
+                  quotedKey: '{{ fromConfigMap "default" "cool-car" "model" }}'
+                rules:
+                  - {{ (lookup "v1" "ConfigMap" "policies" "coolest-car").data.model }}
+                  - '{{ lookup "v1" "ConfigMap" "policies" "coolest-car").data.model }}'
+                  - host: {{ fromConfigMap "default" "cool-car" "model" }}
+                  - port: '{{hub .ManagedClusterName }}'

--- a/cmd/template-resolver/testdata/test_linting_valid_template_hub/config.yaml
+++ b/cmd/template-resolver/testdata/test_linting_valid_template_hub/config.yaml
@@ -1,0 +1,1 @@
+lint: true

--- a/cmd/template-resolver/testdata/test_linting_valid_template_hub/input.yaml
+++ b/cmd/template-resolver/testdata/test_linting_valid_template_hub/input.yaml
@@ -1,0 +1,29 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: valid-template-test
+spec:
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: valid-template-config
+        spec:
+          remediationAction: enforce
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: '{{ fromConfigMap "default" "cool-car" "model" }}'
+                data:
+                  quotedKey: '{{ fromConfigMap "default" "cool-car" "model" }}'
+                  anotherKey: "{{hub .ManagedClusterName hub}}"
+                rules:
+                  - '{{ (lookup "v1" "ConfigMap" "policies" "coolest-car").data.model }}'
+                  - "{{hub .ManagedClusterName hub}}"
+                  - host: '{{ fromConfigMap "default" "cool-car" "model" }}'
+                  - port: "{{hub .ManagedClusterName hub}}"

--- a/cmd/template-resolver/testdata/test_linting_valid_template_hub/output.yaml
+++ b/cmd/template-resolver/testdata/test_linting_valid_template_hub/output.yaml
@@ -1,0 +1,29 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: valid-template-test
+spec:
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: valid-template-config
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  anotherKey: local-cluster
+                  quotedKey: Shelby Mustang
+                kind: ConfigMap
+                metadata:
+                  name: Shelby Mustang
+                rules:
+                  - Subaru Baja
+                  - local-cluster
+                  - host: Shelby Mustang
+                  - port: local-cluster
+          remediationAction: enforce
+          severity: low

--- a/cmd/template-resolver/utils/resolver_utils.go
+++ b/cmd/template-resolver/utils/resolver_utils.go
@@ -70,6 +70,10 @@ func HandleFile(yamlFile string) ([]byte, error) {
 	return yamlBytes, nil
 }
 
+func Lint(yamlString string) []templates.LinterRuleViolation {
+	return templates.Lint(yamlString)
+}
+
 // ProcessTemplate takes a YAML byte array input, unmarshals it to a Policy, ConfigPolicy,
 // or object-templates-raw, processes the templates, and marshals it back to YAML,
 // returning the resulting byte array. Validation is performed along the way, returning

--- a/pkg/templates/lint.go
+++ b/pkg/templates/lint.go
@@ -1,0 +1,225 @@
+package templates
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type LinterRuleViolation struct {
+	LineNumber    int
+	RuleName      string
+	Message       string
+	FormattedLine string
+}
+
+// trailingWhitespace checks each line of the input template string for
+// trailing whitespace. If any line contains trailing spaces or tabs, it returns
+// an error indicating the line number and content. Otherwise, it returns nil.
+func trailingWhitespace(templateStr string) []LinterRuleViolation {
+	ruleName := "trailingWhitespace"
+
+	var violations []LinterRuleViolation
+
+	lines := strings.Split(templateStr, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimLeft(line, " \t")
+
+		// Skip empty lines or comments
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		if strings.TrimRight(trimmed, " \t") != trimmed {
+			violations = append(violations, LinterRuleViolation{
+				LineNumber:    i + 1,
+				RuleName:      ruleName,
+				Message:       "trailing whitespace detected",
+				FormattedLine: trimmed + "<<<",
+			})
+		}
+	}
+
+	return violations
+}
+
+// mismatchedDelimiters checks for mismatched delimiters in the template string.
+// It returns an error if the delimiters are not all paired.
+func mismatchedDelimiters(templateStr string) []LinterRuleViolation {
+	ruleName := "mismatchedDelimiters"
+
+	var violations []LinterRuleViolation
+
+	// This regex finds all template delimiters: {{ or {{hub
+	delimiterRegEx := regexp.MustCompile(`({{(hub)?-?)|(-?(hub)?}})`)
+
+	type delimiter struct {
+		isOpen bool
+		isHub  bool
+		value  string
+		line   int
+	}
+
+	var delimiters []delimiter
+
+	lines := strings.Split(templateStr, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		// Skip empty lines or comments
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		lineNum := i + 1
+		matches := delimiterRegEx.FindAllString(trimmed, -1)
+
+		for _, match := range matches {
+			isOpen := strings.HasPrefix(match, "{{")
+			isHub := strings.Contains(match, "hub")
+			delim := delimiter{
+				value:  match,
+				isOpen: isOpen,
+				isHub:  isHub,
+				line:   lineNum,
+			}
+			delimiters = append(delimiters, delim)
+		}
+	}
+
+	openDelimiters := []delimiter{}
+	openDelimiter := -1
+
+	for _, delimiter := range delimiters {
+		switch {
+		case delimiter.isOpen:
+			openDelimiters = append(openDelimiters, delimiter)
+			openDelimiter++
+
+		case len(openDelimiters) == 0 && !delimiter.isOpen:
+			violations = append(violations, LinterRuleViolation{
+				LineNumber:    delimiter.line,
+				RuleName:      ruleName,
+				Message:       fmt.Sprintf("unmatched closing delimiter '%s'", delimiter.value),
+				FormattedLine: strings.TrimSpace(lines[delimiter.line-1]),
+			})
+
+		case !delimiter.isOpen:
+			matchingOpen := openDelimiters[openDelimiter]
+			if matchingOpen.isHub != delimiter.isHub {
+				violations = append(violations, LinterRuleViolation{
+					LineNumber:    delimiter.line,
+					RuleName:      ruleName,
+					Message:       "mismatched hub and managed cluster delimiters",
+					FormattedLine: strings.TrimSpace(lines[delimiter.line-1]),
+				})
+			}
+
+			openDelimiters = openDelimiters[:openDelimiter]
+			openDelimiter--
+		}
+	}
+
+	for _, delimiter := range openDelimiters {
+		violations = append(violations, LinterRuleViolation{
+			LineNumber:    delimiter.line,
+			RuleName:      ruleName,
+			Message:       fmt.Sprintf("unmatched opening delimiter '%s'", delimiter.value),
+			FormattedLine: strings.TrimSpace(lines[delimiter.line-1]),
+		})
+	}
+
+	return violations
+}
+
+// unquotedTemplateValues checks for unquoted template values in the template
+// string. It returns an error if the template values are not single-quoted.
+func unquotedTemplateValues(templateStr string) []LinterRuleViolation {
+	ruleName := "unquotedTemplateValues"
+
+	var violations []LinterRuleViolation
+
+	lines := strings.Split(templateStr, "\n")
+
+	// Regex to match a line that is an array item with a template, e.g. "- {{ something }}"
+	arrayItemRe := regexp.MustCompile(`^\s*-\s*{{.*}}.*$`)
+	// Regex to match a line that is an array item with a *quoted* template, e.g. "- '{{ something }}'"
+	arrayItemQuotedRe := regexp.MustCompile(`^\s*-\s*'{{.*}}.*'$`)
+
+	// Regex to match a line that is a key with a template value, e.g. "key: {{ something }}"
+	keyValueRe := regexp.MustCompile(`^\s*[^:]+:\s*{{.*}}.*$`)
+	// Regex to match a line that is a key with a *quoted* template value, e.g. "key: '{{ something }}'"
+	keyValueQuotedRe := regexp.MustCompile(`^\s*[^:]+:\s*'{{.*}}.*'$`)
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Skip empty lines or comments
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// Check for unquoted templated array value
+		if arrayItemRe.MatchString(line) && !arrayItemQuotedRe.MatchString(line) {
+			violations = append(
+				violations, LinterRuleViolation{
+					LineNumber:    i + 1,
+					RuleName:      ruleName,
+					Message:       "array item template should be single-quoted",
+					FormattedLine: trimmed,
+				})
+
+			continue
+		}
+
+		// Check for unquoted templated key-value
+		if keyValueRe.MatchString(line) && !keyValueQuotedRe.MatchString(line) {
+			violations = append(
+				violations, LinterRuleViolation{
+					LineNumber:    i + 1,
+					RuleName:      ruleName,
+					Message:       "template value for key should be single-quoted",
+					FormattedLine: trimmed,
+				})
+
+			continue
+		}
+	}
+
+	return violations
+}
+
+func OutputStringViolations(violations []LinterRuleViolation) string {
+	var output strings.Builder
+	for _, violation := range violations {
+		output.WriteString(fmt.Sprintf("line %d: %s: %s:\n\t%s\n",
+			violation.LineNumber, violation.RuleName, violation.Message, violation.FormattedLine))
+	}
+
+	return output.String()
+}
+
+// lint checks the template string for linting errors.
+func Lint(templateStr string) []LinterRuleViolation {
+	var violations []LinterRuleViolation
+
+	lintingChecks := []func(string) []LinterRuleViolation{
+		trailingWhitespace,
+		mismatchedDelimiters,
+		unquotedTemplateValues,
+	}
+
+	for _, check := range lintingChecks {
+		violations = append(violations, check(templateStr)...)
+	}
+
+	if len(violations) > 0 {
+		sort.Slice(violations, func(i, j int) bool {
+			return violations[i].LineNumber < violations[j].LineNumber
+		})
+
+		return violations
+	}
+
+	return nil
+}

--- a/testdata/crds.yaml
+++ b/testdata/crds.yaml
@@ -46,7 +46,7 @@ spec:
             description: Spec defines the attributes of the ClusterClaim.
             properties:
               value:
-                description: Value is a claim-dependent string
+                description: value is a claim-dependent string
                 maxLength: 1024
                 minLength: 1
                 type: string
@@ -149,7 +149,7 @@ spec:
               leaseDurationSeconds:
                 default: 60
                 description: |-
-                  LeaseDurationSeconds is used to coordinate the lease update time of Klusterlet agents on the managed cluster.
+                  leaseDurationSeconds is used to coordinate the lease update time of Klusterlet agents on the managed cluster.
                   If its value is zero, the Klusterlet agent will update its lease every 60 seconds by default
                 format: int32
                 type: integer
@@ -177,7 +177,7 @@ spec:
                 type: array
               taints:
                 description: |-
-                  Taints is a property of managed cluster that allow the cluster to be repelled when scheduling.
+                  taints is a property of managed cluster that allow the cluster to be repelled when scheduling.
                   Taints, including 'ManagedClusterUnavailable' and 'ManagedClusterUnreachable', can not be added/removed by agent
                   running on the managed cluster; while it's fine to add/remove other taints from either hub cluser or managed cluster.
                 items:
@@ -187,7 +187,7 @@ spec:
                   properties:
                     effect:
                       description: |-
-                        Effect indicates the effect of the taint on placements that do not tolerate the taint.
+                        effect indicates the effect of the taint on placements that do not tolerate the taint.
                         Valid effects are NoSelect, PreferNoSelect and NoSelectIfNew.
                       enum:
                       - NoSelect
@@ -196,19 +196,19 @@ spec:
                       type: string
                     key:
                       description: |-
-                        Key is the taint key applied to a cluster. e.g. bar or foo.example.com/bar.
+                        key is the taint key applied to a cluster. e.g. bar or foo.example.com/bar.
                         The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                     timeAdded:
-                      description: TimeAdded represents the time at which the taint
+                      description: timeAdded represents the time at which the taint
                         was added.
                       format: date-time
                       nullable: true
                       type: string
                     value:
-                      description: Value is the taint value corresponding to the taint
+                      description: value is the taint value corresponding to the taint
                         key.
                       maxLength: 1024
                       type: string
@@ -228,7 +228,7 @@ spec:
                   - type: string
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
-                description: Allocatable represents the total allocatable resources
+                description: allocatable represents the total allocatable resources
                   on the managed cluster.
                 type: object
               capacity:
@@ -239,12 +239,12 @@ spec:
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
                 description: |-
-                  Capacity represents the total resource capacity from all nodeStatuses
+                  capacity represents the total resource capacity from all nodeStatuses
                   on the managed cluster.
                 type: object
               clusterClaims:
                 description: |-
-                  ClusterClaims represents cluster information that a managed cluster claims,
+                  clusterClaims represents cluster information that a managed cluster claims,
                   for example a unique cluster identifier (id.k8s.io) and kubernetes version
                   (kubeversion.open-cluster-management.io). They are written from the managed
                   cluster. The set of claims is not uniform across a fleet, some claims can be
@@ -255,20 +255,20 @@ spec:
                   properties:
                     name:
                       description: |-
-                        Name is the name of a ClusterClaim resource on managed cluster. It's a well known
+                        name is the name of a ClusterClaim resource on managed cluster. It's a well known
                         or customized name to identify the claim.
                       maxLength: 253
                       minLength: 1
                       type: string
                     value:
-                      description: Value is a claim-dependent string
+                      description: value is a claim-dependent string
                       maxLength: 1024
                       minLength: 1
                       type: string
                   type: object
                 type: array
               conditions:
-                description: Conditions contains the different condition statuses
+                description: conditions contains the different condition statuses
                   for this managed cluster.
                 items:
                   description: Condition contains details for one aspect of the current
@@ -325,12 +325,94 @@ spec:
                   - type
                   type: object
                 type: array
+              managedNamespaces:
+                description: |-
+                  managedNamespaces are a list of namespaces managed by the clustersets the
+                  cluster belongs to.
+                items:
+                  properties:
+                    clusterSet:
+                      description: clusterSet represents the name of the cluster set.
+                      type: string
+                    conditions:
+                      description: conditions are the status conditions of the managed
+                        namespace
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    name:
+                      description: name is the name of the namespace.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - clusterSet
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - clusterSet
+                - name
+                x-kubernetes-list-type: map
               version:
-                description: Version represents the kubernetes version of the managed
+                description: version represents the kubernetes version of the managed
                   cluster.
                 properties:
                   kubernetes:
-                    description: Kubernetes is the kubernetes version of managed cluster.
+                    description: kubernetes is the kubernetes version of managed cluster.
                     type: string
                 type: object
             type: object


### PR DESCRIPTION
Adds a `--lint` argument to the `template-resolver` to output linting issues along with the output. Linting output is to stderr, so can be filtered out if it raises issues that might be associated with a valid template. The new `lint.go` file contains separate lint functions and then iterates over them, so adding a new linting rule function is relatively straightforward.

I didn't track which ones I've covered here in this PR, but this doc is a collection of linting messages that I had been compiling that could serve as a guide to new rules to add: https://docs.google.com/document/d/1dVmpTgwy7AySYa3ScCr1FE0P_G1uBpLRXLeA94i97dw/edit?tab=t.0#heading=h.xac5cv9qxxk6

I debated having a subcommand, but I think toggling it on/off makes sense and is convenient. Currently the linting isn't aware whether it's inside of multiline strings or not, so that could be an enhancement to this code.

A subsequent path could be to attach some of these to known errors and provide a suggestion message as part of the error passed to users, which is also displayed in the UI.

ref: https://issues.redhat.com/browse/ACM-20101