### PR TITLE
feat: add `lint` subcommand

### DIFF
--- a/cmd/template-resolver/client_test.go
+++ b/cmd/template-resolver/client_test.go
@@ -107,7 +107,7 @@ func cliTest(testName string) func(t *testing.T) {
 		var lintingBytes []byte
 
 		if tmplResolver.Lint {
-			violations := utils.Lint(string(inputBytes))
+			violations := lint.Lint(string(inputBytes))
 
 			if len(violations) > 0 {
 				lintingBytes = []byte("Found linting issues:\n" + lint.OutputStringViolations(violations) + "\n")

--- a/cmd/template-resolver/utils/resolver_client.go
+++ b/cmd/template-resolver/utils/resolver_client.go
@@ -39,6 +39,8 @@ func (t *TemplateResolver) GetCmd() *cobra.Command {
 		RunE:  t.resolveTemplates,
 	}
 
+	templateResolverCmd.AddCommand(t.getLintCmd())
+
 	// Initialize variables used to collect user input from CLI flags
 	// Add template-resolver command and parse flags
 	templateResolverCmd.Flags().StringVar(
@@ -130,27 +132,68 @@ func (t *TemplateResolver) GetCmd() *cobra.Command {
 	return templateResolverCmd
 }
 
+func (t *TemplateResolver) getLintCmd() *cobra.Command {
+	lintCmd := &cobra.Command{
+		Use: `lint [flags] [file|-]
+
+  The file positional argument is the path to a policy YAML manifest. If file
+  is a dash ('-') or absent, template-resolver reads from the standard input.`,
+		Short: "Lint Policy templates",
+		Long:  "Lint Policy templates",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  t.runLint,
+	}
+
+	lintCmd.Flags().StringVar(
+		&t.SarifOutput,
+		"sarif",
+		"",
+		"(Tech Preview) Location to save a SARIF report of the lint results.",
+	)
+
+	return lintCmd
+}
+
+func runLint(cmd *cobra.Command, yamlFile string, yamlBytes []byte, sarifOutput string) error {
+	violations := lint.Lint(string(yamlBytes))
+	if len(violations) > 0 {
+		cmd.Println("Found linting issues:")
+		cmd.Print(lint.OutputStringViolations(violations))
+	}
+
+	if sarifOutput == "" {
+		return nil
+	}
+
+	inputFile := yamlFile
+	if inputFile == "" || inputFile == "-" {
+		inputFile = "<stdin>"
+	}
+
+	file, err := os.Create(sarifOutput) //#nosec G304 -- files accessed here are on the user's local system
+	if err != nil {
+		return fmt.Errorf("failed to open output SARIF report file: %w", err)
+	}
+
+	defer file.Close()
+
+	if err := lint.OutputSARIF(violations, inputFile, file); err != nil {
+		return fmt.Errorf("failed to write SARIF report: %w", err)
+	}
+
+	return nil
+}
+
+func (t *TemplateResolver) runLint(cmd *cobra.Command, args []string) error {
+	yamlFile, yamlBytes, err := getInputYAML(args)
+	if err != nil {
+		return err
+	}
+
+	return runLint(cmd, yamlFile, yamlBytes, t.SarifOutput)
+}
+
 func (t *TemplateResolver) resolveTemplates(cmd *cobra.Command, args []string) error {
-	// Validate YAML input as positional arg
-	yamlFile := ""
-
-	// Detect whether stdin is provided when no arguments are provided
-	if len(args) == 0 {
-		stdinInfo, err := os.Stdin.Stat()
-		if err != nil {
-			return fmt.Errorf("error reading stdin: %w", err)
-		}
-
-		if (stdinInfo.Mode() & os.ModeCharDevice) != 0 {
-			return errors.New("failed to read from stdin: input is not a pipe")
-		}
-	}
-
-	// Set YAML path if a positional argument is provided ("-" is read as stdin)
-	if len(args) == 1 {
-		yamlFile = args[0]
-	}
-
 	// Validate flag args
 	if t.HubKubeConfigPath != "" && t.ClusterName == "" {
 		return errors.New(
@@ -159,34 +202,17 @@ func (t *TemplateResolver) resolveTemplates(cmd *cobra.Command, args []string) e
 		)
 	}
 
-	yamlBytes, err := HandleFile(yamlFile)
+	yamlFile, yamlBytes, err := getInputYAML(args)
 	if err != nil {
-		return fmt.Errorf("error handling YAML file input: %w", err)
+		return err
 	}
 
 	if t.Lint {
-		violations := Lint(string(yamlBytes))
-		if len(violations) > 0 {
-			cmd.Println("Found linting issues:")
-			cmd.Println(lint.OutputStringViolations(violations) + "\n")
+		if err := runLint(cmd, yamlFile, yamlBytes, t.SarifOutput); err != nil {
+			return err
 		}
 
-		if t.SarifOutput != "" {
-			// Determine input file path for SARIF report
-			inputFile := yamlFile
-			if inputFile == "" || inputFile == "-" {
-				inputFile = "<stdin>"
-			}
-
-			file, err := os.Create(t.SarifOutput)
-			if err != nil {
-				return fmt.Errorf("failed to open output SARIF report file: %w", err)
-			}
-
-			if err := lint.OutputSARIF(violations, inputFile, file); err != nil {
-				return fmt.Errorf("failed to write SARIF report: %w", err)
-			}
-		}
+		cmd.Println()
 	}
 
 	resolvedYAML, err := t.ProcessTemplate(yamlBytes)

--- a/cmd/template-resolver/utils/resolver_utils.go
+++ b/cmd/template-resolver/utils/resolver_utils.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	k8syaml "sigs.k8s.io/yaml"
 
-	"github.com/stolostron/go-template-utils/v7/pkg/lint"
 	"github.com/stolostron/go-template-utils/v7/pkg/templates"
 )
 
@@ -104,8 +103,30 @@ func decodeLocalResources(localResourcesPath string) ([]unstructured.Unstructure
 	return localResources, nil
 }
 
-func Lint(yamlString string) []lint.LinterRuleViolation {
-	return lint.Lint(yamlString)
+func getInputYAML(args []string) (string, []byte, error) {
+	yamlFile := ""
+
+	if len(args) == 0 {
+		stdinInfo, err := os.Stdin.Stat()
+		if err != nil {
+			return "", nil, fmt.Errorf("error reading stdin: %w", err)
+		}
+
+		if (stdinInfo.Mode() & os.ModeCharDevice) != 0 {
+			return "", nil, errors.New("failed to read from stdin: input is not a pipe")
+		}
+	}
+
+	if len(args) == 1 {
+		yamlFile = args[0]
+	}
+
+	yamlBytes, err := HandleFile(yamlFile)
+	if err != nil {
+		return "", nil, fmt.Errorf("error handling YAML file input: %w", err)
+	}
+
+	return yamlFile, yamlBytes, nil
 }
 
 // ProcessTemplate takes a YAML byte array input, unmarshals it to a Policy, ConfigPolicy,

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -87,14 +87,14 @@ func OutputStringViolations(violations []LinterRuleViolation) string {
 	for _, violation := range violations {
 		ruleMD := getRuleMetadata(violation.RuleID)
 		if ruleMD == nil {
-			output.WriteString(fmt.Sprintf("line %d: unknown rule: %s: %s:\n\t%s\n",
-				violation.LineNumber, violation.RuleID, violation.ShortMessage, violation.FormattedLine))
+			fmt.Fprintf(&output, "line %d: unknown rule: %s: %s:\n\t%s\n",
+				violation.LineNumber, violation.RuleID, violation.ShortMessage, violation.FormattedLine)
 
 			continue
 		}
 
-		output.WriteString(fmt.Sprintf("line %d: %s: %s:\n\t%s\n",
-			violation.LineNumber, ruleMD.Name, violation.ShortMessage, violation.FormattedLine))
+		fmt.Fprintf(&output, "line %d: %s: %s:\n\t%s\n",
+			violation.LineNumber, ruleMD.Name, violation.ShortMessage, violation.FormattedLine)
 	}
 
 	return output.String()


### PR DESCRIPTION
This isolates linting functionality into a subcommand. It does not yet raise errors from template rendering like misformatted YAML nor the final error message--only runs the linting rules.

ref: https://redhat.atlassian.net/browse/ACM-30370

Assisted-by: Cursor IDE