### PR TITLE
chore: refine `lint` subcommand output

### DIFF
--- a/cmd/template-resolver/client.go
+++ b/cmd/template-resolver/client.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 
 	"github.com/stolostron/go-template-utils/v7/cmd/template-resolver/utils"
@@ -11,6 +12,11 @@ import (
 func main() {
 	err := utils.Execute()
 	if err != nil {
+		var exitErr *utils.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.Code)
+		}
+
 		os.Exit(1)
 	}
 }

--- a/cmd/template-resolver/testdata/test_linting_invalid_var/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_invalid_var/report.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "driver": {
-          "name": "go-template-utils-linter",
+          "name": "Go Template Utils Linter",
           "informationUri": "https://github.com/stolostron/go-template-utils",
           "rules": [
             {

--- a/cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/report.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "driver": {
-          "name": "go-template-utils-linter",
+          "name": "Go Template Utils Linter",
           "informationUri": "https://github.com/stolostron/go-template-utils",
           "rules": [
             {

--- a/cmd/template-resolver/testdata/test_linting_multiple_errors/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_multiple_errors/report.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "driver": {
-          "name": "go-template-utils-linter",
+          "name": "Go Template Utils Linter",
           "informationUri": "https://github.com/stolostron/go-template-utils",
           "rules": [
             {

--- a/cmd/template-resolver/testdata/test_linting_quote_errors_raw/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_quote_errors_raw/report.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "driver": {
-          "name": "go-template-utils-linter",
+          "name": "Go Template Utils Linter",
           "informationUri": "https://github.com/stolostron/go-template-utils",
           "rules": [
             {

--- a/cmd/template-resolver/testdata/test_linting_quote_valid_raw/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_quote_valid_raw/report.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "driver": {
-          "name": "go-template-utils-linter",
+          "name": "Go Template Utils Linter",
           "informationUri": "https://github.com/stolostron/go-template-utils",
           "rules": []
         }

--- a/cmd/template-resolver/testdata/test_linting_trailing_whitespace/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_trailing_whitespace/report.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "driver": {
-          "name": "go-template-utils-linter",
+          "name": "Go Template Utils Linter",
           "informationUri": "https://github.com/stolostron/go-template-utils",
           "rules": [
             {

--- a/cmd/template-resolver/testdata/test_linting_unquoted_values/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_unquoted_values/report.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "driver": {
-          "name": "go-template-utils-linter",
+          "name": "Go Template Utils Linter",
           "informationUri": "https://github.com/stolostron/go-template-utils",
           "rules": [
             {

--- a/cmd/template-resolver/testdata/test_linting_valid_template_hub/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_valid_template_hub/report.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "driver": {
-          "name": "go-template-utils-linter",
+          "name": "Go Template Utils Linter",
           "informationUri": "https://github.com/stolostron/go-template-utils",
           "rules": []
         }

--- a/cmd/template-resolver/testdata/test_linting_var_unused_hub/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_var_unused_hub/report.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "driver": {
-          "name": "go-template-utils-linter",
+          "name": "Go Template Utils Linter",
           "informationUri": "https://github.com/stolostron/go-template-utils",
           "rules": [
             {

--- a/cmd/template-resolver/testdata/test_linting_var_used_hub/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_var_used_hub/report.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "driver": {
-          "name": "go-template-utils-linter",
+          "name": "Go Template Utils Linter",
           "informationUri": "https://github.com/stolostron/go-template-utils",
           "rules": []
         }

--- a/cmd/template-resolver/testdata/test_linting_var_valid_raw_hub/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_var_valid_raw_hub/report.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "driver": {
-          "name": "go-template-utils-linter",
+          "name": "Go Template Utils Linter",
           "informationUri": "https://github.com/stolostron/go-template-utils",
           "rules": []
         }

--- a/cmd/template-resolver/utils/resolver_client.go
+++ b/cmd/template-resolver/utils/resolver_client.go
@@ -26,13 +26,23 @@ type TemplateResolver struct {
 	SarifOutput          string `yaml:"sarif"`
 }
 
+type ExitError struct {
+	Code int
+	Err  error
+}
+
+// Error is a no-op to satisfy the error interface
+func (e *ExitError) Error() string { return "" }
+
 func (t *TemplateResolver) GetCmd() *cobra.Command {
 	// templateResolverCmd represents the template-resolver command
 	templateResolverCmd := &cobra.Command{
 		Use: `template-resolver [flags] [file|-]
 
   The file positional argument is the path to a policy YAML manifest. If file 
-  is a dash ('-') or absent, template-resolver reads from the standard input.`,
+  is a dash ('-') or absent, template-resolver reads from the standard input.
+	Resolved output is printed to stdout while linting or templating errors are 
+	printed to stderr.`,
 		Short: "Locally resolve Policy templates",
 		Long:  "Locally resolve Policy templates",
 		Args:  cobra.MaximumNArgs(1),
@@ -137,7 +147,9 @@ func (t *TemplateResolver) getLintCmd() *cobra.Command {
 		Use: `lint [flags] [file|-]
 
   The file positional argument is the path to a policy YAML manifest. If file
-  is a dash ('-') or absent, template-resolver reads from the standard input.`,
+  is a dash ('-') or absent, template-resolver reads from the standard input.
+	Linting violations are printed to stdout. Exit code 2 is returned if linting 
+	violations are found; other errors may return different exit codes.`,
 		Short: "Lint Policy templates",
 		Long:  "Lint Policy templates",
 		Args:  cobra.MaximumNArgs(1),
@@ -156,13 +168,28 @@ func (t *TemplateResolver) getLintCmd() *cobra.Command {
 
 func runLint(cmd *cobra.Command, yamlFile string, yamlBytes []byte, sarifOutput string) error {
 	violations := lint.Lint(string(yamlBytes))
+	returnViolationError := func() error {
+		if cmd.CalledAs() == "lint" && len(violations) > 0 {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			return &ExitError{Code: 2, Err: nil}
+		}
+
+		return nil
+	}
+
 	if len(violations) > 0 {
+		if cmd.CalledAs() == "lint" {
+			cmd.SetOut(os.Stdout)
+		}
+
 		cmd.Println("Found linting issues:")
 		cmd.Print(lint.OutputStringViolations(violations))
 	}
 
 	if sarifOutput == "" {
-		return nil
+		return returnViolationError()
 	}
 
 	inputFile := yamlFile
@@ -181,7 +208,7 @@ func runLint(cmd *cobra.Command, yamlFile string, yamlBytes []byte, sarifOutput 
 		return fmt.Errorf("failed to write SARIF report: %w", err)
 	}
 
-	return nil
+	return returnViolationError()
 }
 
 func (t *TemplateResolver) runLint(cmd *cobra.Command, args []string) error {

--- a/cmd/template-resolver/utils/resolver_utils.go
+++ b/cmd/template-resolver/utils/resolver_utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -126,7 +127,7 @@ func getInputYAML(args []string) (string, []byte, error) {
 		return "", nil, fmt.Errorf("error handling YAML file input: %w", err)
 	}
 
-	return yamlFile, yamlBytes, nil
+	return filepath.Clean(yamlFile), yamlBytes, nil
 }
 
 // ProcessTemplate takes a YAML byte array input, unmarshals it to a Policy, ConfigPolicy,

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -156,7 +156,7 @@ func OutputSARIF(violations []LinterRuleViolation, inputFile string, output io.W
 		results = append(results, res)
 	}
 
-	run := sarif.NewRun("go-template-utils-linter", "https://github.com/stolostron/go-template-utils").
+	run := sarif.NewRun("Go Template Utils Linter", "https://github.com/stolostron/go-template-utils").
 		WithRules(rules...).
 		WithArtifacts(sarif.NewArtifact(inputFile)).
 		WithResults(results...)


### PR DESCRIPTION
- Print to `stdout` (printing to `stderr` is preserved for the `--lint` flag so that it can be filtered out)
- Set a `2` error code to distinguish linting violations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lint violations reliably return exit code 2 and cause the process to exit with that code.
  * Lint output is correctly routed to standard output when running the lint command.
  * Input file paths are normalized to avoid inconsistent path handling.
  * Error exit handling updated to preserve existing behavior for unknown errors.

* **Documentation**
  * Help text clarified around resolved output, linting/templating errors, and exit-code behavior.
* **Style**
  * Generated SARIF now uses a human-readable run title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->