### PR TITLE
fix: include JSON braces in RegEx

### DIFF
--- a/cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/error.txt
+++ b/cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/error.txt
@@ -1,8 +1,14 @@
 Found linting issues:
-line 21: mismatchedDelimiters: unmatched opening delimiter '{{hub':
+line 21: mismatchedDelimiters: mismatched JSON and template delimiters:
 	name: "{{hub .ManagedClusterName }"
-line 23: mismatchedDelimiters: unmatched opening delimiter '{{hub':
+line 23: mismatchedDelimiters: mismatched JSON and template delimiters:
 	unclosed: "{{hub .ManagedClusterName }"
+line 24: mismatchedDelimiters: mismatched JSON and template delimiters:
+	wrongClose: '{{ fromConfigMap "default" "config" "value" }hub}'
+line 24: mismatchedDelimiters: unmatched closing delimiter '}':
+	wrongClose: '{{ fromConfigMap "default" "config" "value" }hub}'
+line 25: mismatchedDelimiters: unmatched closing delimiter '}}':
+	extraClose: "already closed }} but here's another"
 line 26: mismatchedDelimiters: mismatched hub and managed cluster delimiters:
 	mixed: '{{hub .ManagedClusterName {{ lookup "v1" "Secret" "default" "" }} .Status }}'
 

--- a/cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/report.sarif
@@ -15,8 +15,8 @@
                 "text": "Template delimiters must be properly paired."
               },
               "fullDescription": {
-                "text": "Template start delimiters (`{{` or `{{hub`) must be paired with a corresponding closing delimiter (`}}` or `hub}}`). Otherwise, the template is invalid.",
-                "markdown": "Template start delimiters (`{{` or `{{hub`) must be paired with a corresponding closing delimiter (`}}` or `hub}}`). Otherwise, the template is invalid."
+                "text": "Template and JSON start delimiters (`{{` or `{{hub` or `{`) must be paired with a corresponding closing delimiter. Otherwise, the template is invalid.",
+                "markdown": "Template and JSON start delimiters (`{{` or `{{hub` or `{`) must be paired with a corresponding closing delimiter. Otherwise, the template is invalid."
               }
             }
           ]
@@ -33,7 +33,7 @@
         {
           "level": "error",
           "message": {
-            "text": "Unmatched opening delimiter '{{hub'."
+            "text": "Mismatched JSON and template delimiters: {{hub ... }"
           },
           "locations": [
             {
@@ -44,7 +44,7 @@
                 },
                 "region": {
                   "startLine": 21,
-                  "startColumn": 26
+                  "startColumn": 52
                 }
               }
             }
@@ -55,7 +55,7 @@
         {
           "level": "error",
           "message": {
-            "text": "Unmatched opening delimiter '{{hub'."
+            "text": "Mismatched JSON and template delimiters: {{hub ... }"
           },
           "locations": [
             {
@@ -66,7 +66,7 @@
                 },
                 "region": {
                   "startLine": 23,
-                  "startColumn": 30
+                  "startColumn": 56
                 }
               }
             }
@@ -77,7 +77,73 @@
         {
           "level": "error",
           "message": {
-            "text": "Mismatched hub and managed cluster delimiters."
+            "text": "Mismatched JSON and template delimiters: {{ ... }"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/input.yaml",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 24,
+                  "startColumn": 76
+                }
+              }
+            }
+          ],
+          "ruleId": "GTUL002",
+          "ruleIndex": 0
+        },
+        {
+          "level": "error",
+          "message": {
+            "text": "Unmatched closing delimiter '}'."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/input.yaml",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 24,
+                  "startColumn": 80
+                }
+              }
+            }
+          ],
+          "ruleId": "GTUL002",
+          "ruleIndex": 0
+        },
+        {
+          "level": "error",
+          "message": {
+            "text": "Unmatched closing delimiter '}}'."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "cmd/template-resolver/testdata/test_linting_mismatched_delimiters_hub/input.yaml",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 25,
+                  "startColumn": 47
+                }
+              }
+            }
+          ],
+          "ruleId": "GTUL002",
+          "ruleIndex": 0
+        },
+        {
+          "level": "error",
+          "message": {
+            "text": "Mismatched hub and managed cluster delimiters: {{hub ... }}"
           },
           "locations": [
             {

--- a/cmd/template-resolver/testdata/test_linting_multiple_errors/error.txt
+++ b/cmd/template-resolver/testdata/test_linting_multiple_errors/error.txt
@@ -9,13 +9,17 @@ line 23: trailingWhitespace: trailing whitespace detected:
 	trailing: "value with trailing"   <<<
 line 24: unquotedTemplateValues: templates should be single-quoted:
 	unquoted: {{ fromConfigMap "default" "config" "value" }}
-line 25: mismatchedDelimiters: unmatched opening delimiter '{{':
+line 25: mismatchedDelimiters: mismatched JSON and template delimiters:
 	unclosed: '{{ lookup "v1" "Secret" "default" "secret'
 line 26: trailingWhitespace: trailing whitespace detected:
 	rules: <<<
 line 27: unquotedTemplateValues: templates for array items should be single-quoted:
 	- {{ lookup "v1" "Secret" "default" "my-secret" }}
-line 28: mismatchedDelimiters: unmatched opening delimiter '{{':
+line 28: mismatchedDelimiters: mismatched JSON and template delimiters:
 	- wrongClose: '{{ fromConfigMap "default" "config" "value" }hub}'
+line 29: mismatchedDelimiters: unmatched closing JSON delimiter '}':
+	- jsonwrong: {"key": "value"}}
+line 30: mismatchedDelimiters: unmatched closing delimiter '}':
+	- jsontriplewrong: {"object":{"key": "value"}}}
 
-failed to parse input to YAML: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{"fromConfigMap \"default\" \"config\" \"name\"":interface {}(nil)}
+failed to parse input to YAML: error converting YAML to JSON: yaml: line 28: did not find expected key

--- a/cmd/template-resolver/testdata/test_linting_multiple_errors/input.yaml
+++ b/cmd/template-resolver/testdata/test_linting_multiple_errors/input.yaml
@@ -26,3 +26,6 @@ spec:
                 rules: 
                   - {{ lookup "v1" "Secret" "default" "my-secret" }}
                   - wrongClose: '{{ fromConfigMap "default" "config" "value" }hub}'
+                  - jsonwrong: {"key": "value"}}
+                  - jsontriplewrong: {"object":{"key": "value"}}}
+                  - json: {"object":{"key": "value"}}

--- a/cmd/template-resolver/testdata/test_linting_multiple_errors/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_multiple_errors/report.sarif
@@ -22,8 +22,8 @@
                 "text": "Template delimiters must be properly paired."
               },
               "fullDescription": {
-                "text": "Template start delimiters (`{{` or `{{hub`) must be paired with a corresponding closing delimiter (`}}` or `hub}}`). Otherwise, the template is invalid.",
-                "markdown": "Template start delimiters (`{{` or `{{hub`) must be paired with a corresponding closing delimiter (`}}` or `hub}}`). Otherwise, the template is invalid."
+                "text": "Template and JSON start delimiters (`{{` or `{{hub` or `{`) must be paired with a corresponding closing delimiter. Otherwise, the template is invalid.",
+                "markdown": "Template and JSON start delimiters (`{{` or `{{hub` or `{`) must be paired with a corresponding closing delimiter. Otherwise, the template is invalid."
               }
             },
             {
@@ -158,7 +158,7 @@
         {
           "level": "error",
           "message": {
-            "text": "Unmatched opening delimiter '{{'."
+            "text": "Mismatched JSON and template delimiters: {{ ... }"
           },
           "locations": [
             {
@@ -223,7 +223,7 @@
         {
           "level": "error",
           "message": {
-            "text": "Unmatched opening delimiter '{{'."
+            "text": "Mismatched JSON and template delimiters: {{ ... }"
           },
           "locations": [
             {
@@ -234,7 +234,51 @@
                 },
                 "region": {
                   "startLine": 28,
-                  "startColumn": 34
+                  "startColumn": 78
+                }
+              }
+            }
+          ],
+          "ruleId": "GTUL002",
+          "ruleIndex": 1
+        },
+        {
+          "level": "error",
+          "message": {
+            "text": "Unmatched closing JSON delimiter '}'."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "cmd/template-resolver/testdata/test_linting_multiple_errors/input.yaml",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 29,
+                  "startColumn": 47
+                }
+              }
+            }
+          ],
+          "ruleId": "GTUL002",
+          "ruleIndex": 1
+        },
+        {
+          "level": "error",
+          "message": {
+            "text": "Unmatched closing delimiter '}'."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "cmd/template-resolver/testdata/test_linting_multiple_errors/input.yaml",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 30,
+                  "startColumn": 65
                 }
               }
             }

--- a/cmd/template-resolver/testdata/test_linting_unquoted_values/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_unquoted_values/report.sarif
@@ -15,8 +15,8 @@
                 "text": "Template delimiters must be properly paired."
               },
               "fullDescription": {
-                "text": "Template start delimiters (`{{` or `{{hub`) must be paired with a corresponding closing delimiter (`}}` or `hub}}`). Otherwise, the template is invalid.",
-                "markdown": "Template start delimiters (`{{` or `{{hub`) must be paired with a corresponding closing delimiter (`}}` or `hub}}`). Otherwise, the template is invalid."
+                "text": "Template and JSON start delimiters (`{{` or `{{hub` or `{`) must be paired with a corresponding closing delimiter. Otherwise, the template is invalid.",
+                "markdown": "Template and JSON start delimiters (`{{` or `{{hub` or `{`) must be paired with a corresponding closing delimiter. Otherwise, the template is invalid."
               }
             },
             {
@@ -176,7 +176,7 @@
         {
           "level": "error",
           "message": {
-            "text": "Mismatched hub and managed cluster delimiters."
+            "text": "Mismatched hub and managed cluster delimiters: {{hub ... }}"
           },
           "locations": [
             {

--- a/cmd/template-resolver/utils/resolver_client.go
+++ b/cmd/template-resolver/utils/resolver_client.go
@@ -148,8 +148,10 @@ func (t *TemplateResolver) getLintCmd() *cobra.Command {
 
   The file positional argument is the path to a policy YAML manifest. If file
   is a dash ('-') or absent, template-resolver reads from the standard input.
-	Linting violations are printed to stdout. Exit code 2 is returned if linting 
-	violations are found; other errors may return different exit codes.`,
+ 	Linting violations are printed to stdout. Exit code 2 is returned if any
+ 	error-level violations are found; exit code 3 is returned when violations
+ 	are found with no error-level results; other errors may return different
+ 	exit codes.`,
 		Short: "Lint Policy templates",
 		Long:  "Lint Policy templates",
 		Args:  cobra.MaximumNArgs(1),
@@ -172,8 +174,18 @@ func runLint(cmd *cobra.Command, yamlFile string, yamlBytes []byte, sarifOutput 
 		if cmd.CalledAs() == "lint" && len(violations) > 0 {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
+			exitCode := 3
 
-			return &ExitError{Code: 2, Err: nil}
+			for _, violation := range violations {
+				ruleMetadata := lint.GetRuleMetadata(violation.RuleID)
+				if ruleMetadata == nil || ruleMetadata.Level == "error" {
+					exitCode = 2
+
+					break
+				}
+			}
+
+			return &ExitError{Code: exitCode, Err: nil}
 		}
 
 		return nil

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -70,8 +70,8 @@ type RuleMetadata struct {
 	Level string
 }
 
-// getRuleMetadata returns the RuleMetadata for a given rule ID, or nil if not found.
-func getRuleMetadata(ruleID string) *RuleMetadata {
+// GetRuleMetadata returns the RuleMetadata for a given rule ID, or nil if not found.
+func GetRuleMetadata(ruleID string) *RuleMetadata {
 	for _, rule := range linterRules {
 		if rule.metadata.ID == ruleID {
 			return &rule.metadata
@@ -85,7 +85,7 @@ func OutputStringViolations(violations []LinterRuleViolation) string {
 	var output strings.Builder
 
 	for _, violation := range violations {
-		ruleMD := getRuleMetadata(violation.RuleID)
+		ruleMD := GetRuleMetadata(violation.RuleID)
 		if ruleMD == nil {
 			fmt.Fprintf(&output, "line %d: unknown rule: %s: %s:\n\t%s\n",
 				violation.LineNumber, violation.RuleID, violation.ShortMessage, violation.FormattedLine)
@@ -122,7 +122,7 @@ func OutputSARIF(violations []LinterRuleViolation, inputFile string, output io.W
 	rules := make([]sarif.Rule, 0, len(usedRuleIDsList))
 
 	for i, ruleID := range usedRuleIDsList {
-		if metadata := getRuleMetadata(ruleID); metadata != nil {
+		if metadata := GetRuleMetadata(ruleID); metadata != nil {
 			rule := sarif.NewRule(metadata.ID, metadata.Name, metadata.ShortDescription)
 
 			if metadata.FullDescription != "" {
@@ -144,7 +144,7 @@ func OutputSARIF(violations []LinterRuleViolation, inputFile string, output io.W
 	results := make([]sarif.Result, 0, len(violations))
 
 	for _, violation := range violations {
-		metadata := getRuleMetadata(violation.RuleID)
+		metadata := GetRuleMetadata(violation.RuleID)
 		if metadata == nil {
 			return fmt.Errorf("unknown rule ID: %v", violation.RuleID)
 		}

--- a/pkg/lint/mismatched-delimiters.go
+++ b/pkg/lint/mismatched-delimiters.go
@@ -11,8 +11,8 @@ var MismatchedDelimiters = LinterRule{
 		ID:               mismatchedDelimitersID,
 		Name:             "mismatchedDelimiters",
 		ShortDescription: "Template delimiters must be properly paired.",
-		FullDescription: "Template start delimiters (`{{` or `{{hub`) must be paired with a corresponding " +
-			"closing delimiter (`}}` or `hub}}`). Otherwise, the template is invalid.",
+		FullDescription: "Template and JSON start delimiters (`{{` or `{{hub` or `{`) " +
+			"must be paired with a corresponding closing delimiter. Otherwise, the template is invalid.",
 		Level: "error",
 	},
 	runLinter: findMismatchedDelimiters,
@@ -23,12 +23,13 @@ const mismatchedDelimitersID = "GTUL002"
 // findMismatchedDelimiters checks for mismatched delimiters in the template string.
 // It returns an error if the delimiters are not all paired.
 func findMismatchedDelimiters(templateStr string) (violations []LinterRuleViolation) {
-	// This regex finds all template delimiters: {{ or {{hub
-	delimiterRegEx := regexp.MustCompile(`({{(hub)?-?)|(-?(hub)?}})`)
+	// This regex finds all template or JSON delimiters: { or {{ or {{hub
+	delimiterRegEx := regexp.MustCompile(`({{(hub)?-?)|(-?(hub)?}}|[{}])`)
 
 	type delimiter struct {
 		isOpen bool
 		isHub  bool
+		isJSON bool
 		value  string
 		line   int
 		column int
@@ -53,8 +54,10 @@ func findMismatchedDelimiters(templateStr string) (violations []LinterRuleViolat
 		for _, match := range matches {
 			bytePos := match[0]
 			matchStr := trimmed[bytePos:match[1]]
-			isOpen := strings.HasPrefix(matchStr, "{{")
+			isOpen := strings.HasPrefix(matchStr, "{")
 			isHub := strings.Contains(matchStr, "hub")
+			isJSON := matchStr == "{" || matchStr == "}"
+
 			// Calculate column in the original line by mapping the position from trimmed to line
 			// The delimiter is at bytePos in trimmed, which maps to leadingWhitespaceLen + bytePos in line
 			column := bytePosToColumn(line, leadingWhitespaceLen+bytePos)
@@ -62,6 +65,7 @@ func findMismatchedDelimiters(templateStr string) (violations []LinterRuleViolat
 				value:  matchStr,
 				isOpen: isOpen,
 				isHub:  isHub,
+				isJSON: isJSON,
 				line:   lineNum,
 				column: column,
 			}
@@ -74,10 +78,12 @@ func findMismatchedDelimiters(templateStr string) (violations []LinterRuleViolat
 
 	for _, delimiter := range delimiters {
 		switch {
+		// If it's an opening delimiter, add it to the list of open delimiters
 		case delimiter.isOpen:
 			openDelimiters = append(openDelimiters, delimiter)
 			openDelimiter++
 
+		// If it's a closing delimiter and there are no open delimiters, add a violation
 		case len(openDelimiters) == 0 && !delimiter.isOpen:
 			violations = append(violations, LinterRuleViolation{
 				LineNumber:    delimiter.line,
@@ -88,16 +94,82 @@ func findMismatchedDelimiters(templateStr string) (violations []LinterRuleViolat
 				Column:        delimiter.column,
 			})
 
+		// If it's a closing delimiter and there are open delimiters,
+		// check if it matches the last open delimiter
 		case !delimiter.isOpen:
 			matchingOpen := openDelimiters[openDelimiter]
-			if matchingOpen.isHub != delimiter.isHub {
+
+			// Handle when it matches a template delimiter
+			// but it's actually paired with a JSON delimiter
+			if delimiter.value == "}}" && matchingOpen.isJSON {
+				openDelimiters = openDelimiters[:openDelimiter]
+				openDelimiter--
+
+				// After consuming the last open delimiter, if there are no more open
+				// delimiters, add a violation for the unmatched closing JSON delimiter
+				if len(openDelimiters) == 0 {
+					violations = append(violations, LinterRuleViolation{
+						LineNumber:    delimiter.line,
+						RuleID:        mismatchedDelimitersID,
+						ShortMessage:  "unmatched closing JSON delimiter '}'",
+						Message:       "Unmatched closing JSON delimiter '}'.",
+						FormattedLine: strings.TrimSpace(lines[delimiter.line-1]),
+						Column:        delimiter.column,
+					})
+
+					continue
+				}
+
+				// Fetch the next open delimiter and check if it's also a JSON delimiter
+				matchingOpen = openDelimiters[openDelimiter]
+				if matchingOpen.isJSON {
+					openDelimiters = openDelimiters[:openDelimiter]
+					openDelimiter--
+
+					continue
+				}
+
+				// If the next open delimiter is not a JSON delimiter,
+				// update the current delimiter to be a JSON delimiter
+				delimiter.value = "}"
+				delimiter.isJSON = true
+				delimiter.column++
+			}
+
+			var line string
+			var lineNum, column int
+
+			// Prefer showing the line of the opening delimiter
+			if matchingOpen.line == delimiter.line {
+				lineNum = matchingOpen.line
+				line = strings.TrimSpace(lines[delimiter.line-1])
+				column = delimiter.column
+			} else {
+				lineNum = matchingOpen.line
+				line = strings.TrimSpace(lines[matchingOpen.line-1])
+				column = matchingOpen.column
+			}
+
+			// Handle when the opening and closing delimiters are mismatched
+			if matchingOpen.isHub != delimiter.isHub && !delimiter.isJSON {
 				violations = append(violations, LinterRuleViolation{
-					LineNumber:    delimiter.line,
-					RuleID:        mismatchedDelimitersID,
-					ShortMessage:  "mismatched hub and managed cluster delimiters",
-					Message:       "Mismatched hub and managed cluster delimiters.",
-					FormattedLine: strings.TrimSpace(lines[delimiter.line-1]),
-					Column:        delimiter.column,
+					LineNumber:   lineNum,
+					RuleID:       mismatchedDelimitersID,
+					ShortMessage: "mismatched hub and managed cluster delimiters",
+					Message: "Mismatched hub and managed cluster delimiters: " +
+						matchingOpen.value + " ... " + delimiter.value,
+					FormattedLine: line,
+					Column:        column,
+				})
+			} else if matchingOpen.isJSON != delimiter.isJSON {
+				violations = append(violations, LinterRuleViolation{
+					LineNumber:   lineNum,
+					RuleID:       mismatchedDelimitersID,
+					ShortMessage: "mismatched JSON and template delimiters",
+					Message: "Mismatched JSON and template delimiters: " +
+						matchingOpen.value + " ... " + delimiter.value,
+					FormattedLine: line,
+					Column:        column,
 				})
 			}
 


### PR DESCRIPTION
JSON braces were confusing the linter. Including them produces more reliable results.

Also adds the match to the output for additional clarity.

ref: https://redhat.atlassian.net/browse/ACM-30859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lint messages now distinguish JSON vs. template delimiter mismatches, provide more accurate locations, and emit separate diagnostics for unmatched or extra closing delimiters.
  * Delimiter recognition improved to handle JSON braces alongside template delimiters for more precise linting and error reporting.
* **Behavior**
  * The lint command now returns different exit codes for error-level vs. warnings-only violations; help text updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->