### PR TITLE
fix: ignore unquoted values in raw string

### DIFF
--- a/cmd/template-resolver/testdata/test_linting_quote_valid_raw/input.yaml
+++ b/cmd/template-resolver/testdata/test_linting_quote_valid_raw/input.yaml
@@ -25,7 +25,7 @@ spec:
                   namespace: '{{ printf "%v%v" .metadata.namespace "blah"}}'
                   labels:
                     ford.com/model: "Mustang"
-                    name: '{{ $.ObjectName }}'
+                    name: {{ $.ObjectName }}
                     escaped: "this quote \" is escaped"
                     valid: 'this quote '' is a valid string'
                     valid-quote-at-start: '"{{ $.ObjectName }}'
@@ -38,3 +38,32 @@ spec:
                     }{{ else }}{{ "{}" | toLiteral }}{{ end }}'
             {{- end }}
             {{- end }}
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: quote-valid-config
+        spec:
+          remediationAction: enforce
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: cool-car
+                  namespace: default
+                  labels:
+                    ford.com/model: "Mustang"
+                    name: '{{ $.ObjectName }}'
+                    escaped: "this quote \" is escaped"
+                    valid: 'this quote '' is a valid string'
+                    valid-quote-at-start: '"{{ $.ObjectName }}'
+                    valid-string: '{{ printf "this apostrophe '' is valid" }}'
+                    also-valid: '{{ printf "this is \"valid\""}}'
+                    note: "this is a string and shouldn't be checked for extra single quotes"
+                    multiline-config: >
+                      {{ $carModel := (fromConfigMap "default" "cool-car"
+                      "model") }}{{ if eq "Shelby Mustang" $carModel }}{"model":"{{ $carModel }}"
+                      }{{ else }}{{ "{}" | toLiteral }}{{ end }}'

--- a/cmd/template-resolver/testdata/test_linting_quote_valid_raw/output.yaml
+++ b/cmd/template-resolver/testdata/test_linting_quote_valid_raw/output.yaml
@@ -31,3 +31,30 @@ spec:
                   namespace: defaultblah
           remediationAction: enforce
           severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: quote-valid-config
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  labels:
+                    also-valid: this is "valid"
+                    escaped: this quote " is escaped
+                    ford.com/model: Mustang
+                    multiline-config:
+                      model: Shelby Mustang
+                    name: my-obj-name
+                    note: this is a string and shouldn't be checked for extra single quotes
+                    valid: this quote ' is a valid string
+                    valid-quote-at-start: '"my-obj-name'
+                    valid-string: this apostrophe ' is valid
+                  name: cool-car
+                  namespace: default
+          remediationAction: enforce
+          severity: low

--- a/cmd/template-resolver/testdata/test_linting_trailing_whitespace/output.yaml
+++ b/cmd/template-resolver/testdata/test_linting_trailing_whitespace/output.yaml
@@ -5,8 +5,6 @@ line 7: trailingWhitespace: trailing whitespace detected:
 	- objectDefinition:	<<<
 line 19: trailingWhitespace: trailing whitespace detected:
 	kind: ConfigMap <<<
-line 23: unquotedTemplateValues: templates should be single-quoted:
-	key: {{ fromConfigMap "default" "cool-car" "model" }}
 line 23: trailingWhitespace: trailing whitespace detected:
 	key: {{ fromConfigMap "default" "cool-car" "model" }}    <<<
 

--- a/cmd/template-resolver/testdata/test_linting_trailing_whitespace/report.sarif
+++ b/cmd/template-resolver/testdata/test_linting_trailing_whitespace/report.sarif
@@ -14,17 +14,6 @@
               "shortDescription": {
                 "text": "Lines should not have trailing whitespace."
               }
-            },
-            {
-              "id": "GTUL003",
-              "name": "unquotedTemplateValues",
-              "shortDescription": {
-                "text": "Template expressions should be single-quoted."
-              },
-              "fullDescription": {
-                "text": "Single-quote wrapping around template expressions in YAML will ensure that the templates are properly interpreted and not interfere with the rest of the structure.",
-                "markdown": "Single-quote wrapping around template expressions in YAML will ensure that the templates are properly interpreted and not interfere with the rest of the structure."
-              }
             }
           ]
         }
@@ -99,28 +88,6 @@
           ],
           "ruleId": "GTUL001",
           "ruleIndex": 0
-        },
-        {
-          "level": "warning",
-          "message": {
-            "text": "Templates should be single-quoted."
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "cmd/template-resolver/testdata/test_linting_trailing_whitespace/input.yaml",
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 23,
-                  "startColumn": 24
-                }
-              }
-            }
-          ],
-          "ruleId": "GTUL003",
-          "ruleIndex": 1
         },
         {
           "level": "warning",

--- a/pkg/lint/unquoted-template-values.go
+++ b/pkg/lint/unquoted-template-values.go
@@ -39,8 +39,22 @@ func findUnquotedTemplateValues(templateStr string) (violations []LinterRuleViol
 	// Regex to match }}''
 	extraDoubleQuoteAfterCloseRe := regexp.MustCompile(`}}''\s*$`)
 
+	isRaw := false
+
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "object-templates-raw: ") {
+			isRaw = true
+		}
+
+		if isRaw {
+			if strings.HasPrefix(trimmed, "object-templates:") {
+				isRaw = false
+			}
+
+			continue
+		}
 
 		// Skip empty lines or comments
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {


### PR DESCRIPTION
Inside of `object-templates-raw`, unquoted template values isn't required since it's already inside of a string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Template linter now properly skips validation checks within raw template sections
  * Removed unnecessary quote validation warnings for template function calls
  * Trailing whitespace detection behavior refined

* **Tests**
  * Expanded test coverage for quote validation and whitespace linting scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->