### PR TITLE
chore: realign Dependabot interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: cron
+      cronjob: "0 7 * * MON#1"
+      timezone: America/New_York
     groups:
       github-actions:
         patterns:
@@ -11,7 +13,9 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
+      interval: cron
+      cronjob: "0 7 * * MON#1"
+      timezone: America/New_York
     groups:
       gomod:
         patterns:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched dependency update schedules to fixed cron-style timing with a specified timezone (America/New_York).
  * Standardized timing for dependency updates to make update windows more predictable.
  * Reduced overlap between update windows for affected ecosystems to improve consistency and scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->