### PR TITLE
fix: treat var reassign as usage in unusedVariables

### DIFF
--- a/cmd/template-resolver/testdata/test_linting_quote_valid_raw/input.yaml
+++ b/cmd/template-resolver/testdata/test_linting_quote_valid_raw/input.yaml
@@ -36,5 +36,11 @@ spec:
                     multiline-config: '{{ $carModel := (fromConfigMap "default" "cool-car"
                     "model") }}{{ if eq "Shelby Mustang" $carModel }}{"model":"{{ $carModel }}"
                     }{{ else }}{{ "{}" | toLiteral }}{{ end }}'
+
+                    {{- $model := "Pinto" }}
+                    {{- if eq (fromConfigMap "default" "cool-car" "model") "Shelby Mustang" }}
+                      {{- $model = "Shelby Mustang" }}
+                    {{- end }}
+                    conditional-reassign-map: '{{ $model }}'
             {{- end }}
             {{- end }}

--- a/cmd/template-resolver/testdata/test_linting_quote_valid_raw/output.yaml
+++ b/cmd/template-resolver/testdata/test_linting_quote_valid_raw/output.yaml
@@ -18,6 +18,7 @@ spec:
                 metadata:
                   labels:
                     also-valid: this is "valid"
+                    conditional-reassign-map: Shelby Mustang
                     escaped: this quote " is escaped
                     ford.com/model: Mustang
                     multiline-config: '{"model":"Shelby Mustang" }'

--- a/cmd/template-resolver/testdata/test_linting_var_valid_raw_hub/input.yaml
+++ b/cmd/template-resolver/testdata/test_linting_var_valid_raw_hub/input.yaml
@@ -26,3 +26,12 @@ spec:
             # These variables are reachable here in object-templates-raw
             hub-value: '{{hub $hubVar hub}}'
             managed-value: '{{ $managedVar }}'
+    - complianceType: musthave
+      objectDefinition:
+        kind: ConfigMap
+        apiVersion: v1
+        metadata:
+          name: conditional-reassign-map
+          labels:
+            # Declared, reassigned with = inside if, then used (ACM-33627)
+            model: '{{ $model := "Pinto" }}{{ if eq (fromConfigMap "default" "cool-car" "model") "Shelby Mustang" }}{{ $model = "Shelby Mustang" }}{{ end }}{{ $model }}'

--- a/cmd/template-resolver/testdata/test_linting_var_valid_raw_hub/output.yaml
+++ b/cmd/template-resolver/testdata/test_linting_var_valid_raw_hub/output.yaml
@@ -22,5 +22,13 @@ spec:
             hub-value: hub-value
             managed-value: managed-value
           name: second-map
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          labels:
+            model: Shelby Mustang
+          name: conditional-reassign-map
   remediationAction: enforce
   severity: low

--- a/pkg/lint/unused-variables.go
+++ b/pkg/lint/unused-variables.go
@@ -32,7 +32,7 @@ func findUnusedVariables(templateStr string) []LinterRuleViolation {
 	}
 
 	varRe := regexp.MustCompile(`\$(\w+)(?:\.\w+)*`)
-	varDefRe := regexp.MustCompile(`\$(\w+)\s*[:=,]`)
+	varDefRe := regexp.MustCompile(`\$(\w+)\s*(?::=|,)`)
 	hubTmplRe := regexp.MustCompile(`{{hub\s+.*?\s+hub}}`)
 	tmplRe := regexp.MustCompile(`{{-?.*?-?}}`)
 	rawTmplRe := regexp.MustCompile(`(?m)^\s*object-templates-raw\s*:`)


### PR DESCRIPTION
The unusedVariables rule should only match := and range commas as declarations. Assignments with = were misclassified as new defs, causing false positives for conditional reassignment inside if blocks.

ref: https://redhat.atlassian.net/browse/ACM-33627

Assisted by AI (Composer 2.5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template linting to accurately identify variable definitions, distinguishing between variable definitions and usage by refining pattern matching.

* **Tests**
  * Updated test fixtures to cover conditional variable reassignment scenarios in template resolution and quote validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->