### PR TITLE
fix: handle error from processRawGoTemplate  flag

### DIFF
--- a/cmd/template-resolver/utils/resolver_utils.go
+++ b/cmd/template-resolver/utils/resolver_utils.go
@@ -281,7 +281,11 @@ func (t *TemplateResolver) ProcessTemplate(yamlBytes []byte) ([]byte, error) {
 	default:
 		if t.SkipPolicyValidation {
 			var resolvedRaw any
+
 			resolvedRaw, err = processRawGoTemplate(string(yamlBytes), resolver, tempCtx)
+			if err != nil {
+				return nil, err
+			}
 
 			if resolved, ok := resolvedRaw.(map[string]interface{}); ok {
 				policy.Object = resolved


### PR DESCRIPTION
Hi!

I was experimenting with --skip-policy-validation where I noticed that the error returned by processRawGoTemplate was getting overwritten by the `if ... resolvedRaw.(map[string]interface{}) `when processRawGoTemplate returns a `nil, error` :(

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template resolution reliability by stopping processing when an underlying template operation fails.
  * Prevented unresolved or invalid results from being processed further when validation is skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->