### PR TITLE
 draft: resolving non-yaml templates

### DIFF
--- a/cmd/template-resolver/testdata/test_notYAML-template_local/config.yaml
+++ b/cmd/template-resolver/testdata/test_notYAML-template_local/config.yaml
@@ -1,0 +1,1 @@
+skipPolicyValidation: true

--- a/cmd/template-resolver/testdata/test_notYAML-template_local/input.yaml
+++ b/cmd/template-resolver/testdata/test_notYAML-template_local/input.yaml
@@ -1,0 +1,45 @@
+{{- $versions := fromConfigMap "ns" "cluster-settings" "component.gitlab-runner.operator.version" -}}
+{{- $channel := fromConfigMap "ns" "cluster-settings" "component.gitlab-runner.operator.channel" -}}
+{{- if and $versions $channel -}}
+{{- $version_list := split "," $versions }}
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
+metadata:
+  name: gitlab-runner-operator
+  namespace: ns
+spec:
+  complianceType: musthave
+  operatorGroup:
+    name: gitlab-runner-operator
+    namespace: operator-gitlab-runner
+  complianceConfig:
+    catalogSourceUnhealthy: Compliant
+    deploymentsUnavailable: NonCompliant
+    deprecationsPresent: Compliant
+    upgradesAvailable: Compliant
+  remediationAction: enforce
+  removalBehavior:
+    clusterServiceVersions: Delete
+    customResourceDefinitions: Keep
+    operatorGroups: DeleteIfUnused
+    subscriptions: Delete
+  subscription:
+    channel: {{ $channel }}
+    config:
+      resources:
+        limits:
+          cpu: 300m
+          memory: 1.5Gi
+        requests:
+          memory: 1Gi
+    name: gitlab-runner-operator
+    namespace: operator-gitlab-runner
+    source: certified-operators
+    sourceNamespace: openshift-marketplace
+    startingCSV: {{ printf "gitlab-runner-operator.v%s" $version_list._0 }}
+  upgradeApproval: Automatic
+  versions:
+  {{ range $v := $version_list }}
+          {{ printf "- gitlab-runner-operator.v%s" $v }}
+  {{ end }}
+  {{ end }}

--- a/cmd/template-resolver/testdata/test_notYAML-template_local/local_resources.yaml
+++ b/cmd/template-resolver/testdata/test_notYAML-template_local/local_resources.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+data:
+    component.gitlab-runner.operator.channel: stable
+    component.gitlab-runner.operator.version: 1.48.3,1.49.0,1.51.0
+kind: ConfigMap
+metadata:
+    name: cluster-settings
+    namespace: ns

--- a/cmd/template-resolver/testdata/test_notYAML-template_local/output.yaml
+++ b/cmd/template-resolver/testdata/test_notYAML-template_local/output.yaml
@@ -1,0 +1,46 @@
+
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
+metadata:
+  name: gitlab-runner-operator
+  namespace: ns
+spec:
+  complianceType: musthave
+  operatorGroup:
+    name: gitlab-runner-operator
+    namespace: operator-gitlab-runner
+  complianceConfig:
+    catalogSourceUnhealthy: Compliant
+    deploymentsUnavailable: NonCompliant
+    deprecationsPresent: Compliant
+    upgradesAvailable: Compliant
+  remediationAction: enforce
+  removalBehavior:
+    clusterServiceVersions: Delete
+    customResourceDefinitions: Keep
+    operatorGroups: DeleteIfUnused
+    subscriptions: Delete
+  subscription:
+    channel: stable
+    config:
+      resources:
+        limits:
+          cpu: 300m
+          memory: 1.5Gi
+        requests:
+          memory: 1Gi
+    name: gitlab-runner-operator
+    namespace: operator-gitlab-runner
+    source: certified-operators
+    sourceNamespace: openshift-marketplace
+    startingCSV: gitlab-runner-operator.v1.48.3
+  upgradeApproval: Automatic
+  versions:
+  
+          - gitlab-runner-operator.v1.48.3
+  
+          - gitlab-runner-operator.v1.49.0
+  
+          - gitlab-runner-operator.v1.51.0
+  
+  

--- a/cmd/template-resolver/testdata/test_notYAML-template_local/save_resources.yaml
+++ b/cmd/template-resolver/testdata/test_notYAML-template_local/save_resources.yaml
@@ -1,0 +1,10 @@
+---
+# Resource was locally fetched
+apiVersion: v1
+data:
+    component.gitlab-runner.operator.channel: stable
+    component.gitlab-runner.operator.version: 1.48.3,1.49.0,1.51.0
+kind: ConfigMap
+metadata:
+    name: cluster-settings
+    namespace: ns

--- a/cmd/template-resolver/utils/resolver_utils.go
+++ b/cmd/template-resolver/utils/resolver_utils.go
@@ -138,9 +138,14 @@ func getInputYAML(args []string) (string, []byte, error) {
 func (t *TemplateResolver) ProcessTemplate(yamlBytes []byte) ([]byte, error) {
 	policy := unstructured.Unstructured{}
 
+	// This is really ugly and just meant to show the idea of processing non-yaml template
+	rawTemplate := make(map[string]interface{})
+	rawTemplate["template"] = yamlBytes
+
 	err := k8syaml.Unmarshal(yamlBytes, &policy.Object)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse input to YAML: %w", err)
+		// Skip this is not a YAML template but rather a raw text template
+		policy.Object = rawTemplate
 	}
 
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -280,14 +285,18 @@ func (t *TemplateResolver) ProcessTemplate(yamlBytes []byte) ([]byte, error) {
 		_, err = processOperatorPolicyTemplates(policy.Object, resolver, tempCtx)
 	default:
 		if t.SkipPolicyValidation {
-			var resolvedRaw any
-			resolvedRaw, err = processRawGoTemplate(string(yamlBytes), resolver, tempCtx)
 
-			if resolved, ok := resolvedRaw.(map[string]interface{}); ok {
-				policy.Object = resolved
-			} else {
-				err = errors.New("failed to cast returned object to map[string]interface{}")
+			resolvedRaw, err := processRawGoTemplate(string(yamlBytes), resolver, tempCtx)
+			if err != nil {
+				return nil, err
 			}
+
+			err = createSaveResourcesOutput(t.SaveResources, resolver)
+			if err != nil {
+				return nil, err
+			}
+
+			return resolvedRaw, nil
 		} else {
 			if _, ok := policy.Object["object-templates-raw"]; !t.SkipPolicyValidation && !ok {
 				return nil, errors.New("invalid YAML. Supported types: Policy, " +
@@ -439,28 +448,25 @@ func processConfigPolicyTemplate(
 	return nil
 }
 
+// process the input template as completely raw text. In processTemplate, it 
+// is required for the input to be YAML, but in this process it can be just text
 func processRawGoTemplate(
 	input string,
 	resolver *templates.TemplateResolver,
 	tempCtx templates.TemplateContext,
-) (resolved any, err error) {
-	resolveOptions := templates.ResolveOptions{InputIsYAML: true}
+) (resolved []byte, err error) {
+	resolveOptions := templates.ResolveOptions{InputIsYAML: false}
 
 	if strings.Contains(input, "{{hub") {
-		return nil, errors.New("unresolved hub template in YAML input. Use the hub-kubeconfig argument")
+		return nil, errors.New("unresolved hub template in text input. Use the hub-kubeconfig argument")
 	}
 
-	tmplResult, err := resolver.ResolveTemplate([]byte(input), tempCtx, &resolveOptions)
+	tmplResult, err := resolver.ResolveRawTemplate([]byte(input), tempCtx, &resolveOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to process the templates: %w", err)
 	}
 
-	err = json.Unmarshal(tmplResult.ResolvedJSON, &resolved)
-	if err != nil {
-		return nil, fmt.Errorf("failed to process the templates: %w", err)
-	}
-
-	return resolved, err
+	return tmplResult.ResolvedJSON, err
 }
 
 // processObjTemplatesRaw takes a YAML string representation and resolves the object's managed templates
@@ -474,9 +480,15 @@ func processObjTemplatesRaw(
 		return errors.New("invalid object-templates-raw after resolving hub templates")
 	}
 
-	resolved, err := processRawGoTemplate(oTRaw, resolver, tempCtx)
+	var resolved any
+	rawTemplateResolved, err := processRawGoTemplate(oTRaw, resolver, tempCtx)
 	if err != nil {
 		return err
+	}
+
+	err = json.Unmarshal(rawTemplateResolved, &resolved)
+	if err != nil {
+		return fmt.Errorf("failed to process the templates: %w", err)
 	}
 
 	var objectTemplates []interface{}

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -586,6 +586,213 @@ func (t *TemplateResolver) EndQueryBatch(watcher client.ObjectIdentifier) error 
 	return t.dynamicWatcher.EndQueryBatch(watcher)
 }
 
+// Resolves Raw Template like ResolveTemplate but with difference that the input is just text 
+// without being in yaml
+func (t *TemplateResolver) ResolveRawTemplate(tmplRaw []byte, context interface{}, options *ResolveOptions) (TemplateResult, error) {
+	klog.V(2).Infof("ResolveTemplate for: %v", string(tmplRaw))
+
+	if options == nil {
+		options = &ResolveOptions{}
+	}
+
+	// Always denylist sensitive functions that can expose host information.
+	if options.DenylistFunctions == nil {
+		options.DenylistFunctions = []string{}
+	}
+
+	options.DenylistFunctions = append(options.DenylistFunctions, sensitiveSprigFunctions...)
+
+	var resolvedResult TemplateResult
+
+	err := validateEncryptionConfig(options.EncryptionConfig)
+	if err != nil {
+		return resolvedResult, fmt.Errorf("error validating EncryptionConfig: %w", err)
+	}
+
+	if t.dynamicWatcher != nil {
+		if options.Watcher == nil {
+			return resolvedResult, fmt.Errorf(
+				"%w: options.Watcher cannot be nil if caching is enabled",
+				ErrInvalidInput,
+			)
+		}
+	} else if len(options.ContextTransformers) != 0 {
+		return resolvedResult, fmt.Errorf(
+			"%w: options.ContextTransformers cannot be set if caching is disabled",
+			ErrInvalidInput,
+		)
+	}
+
+	ctx, err := getValidContext(context)
+	if err != nil {
+		return resolvedResult, err
+	}
+
+	// Build Map of supported template functions
+	funcMap := template.FuncMap{
+		"copyConfigMapData":      t.copyConfigMapDataHelper(options),
+		"copySecretData":         t.copySecretDataHelper(options, &resolvedResult),
+		"fromSecret":             t.fromSecretHelper(options, &resolvedResult),
+		"fromConfigMap":          t.fromConfigMapHelper(options),
+		"fromClusterClaim":       t.fromClusterClaimHelper(options),
+		"lookupClusterClaim":     t.lookupClusterClaimHelper(options),
+		"getNodesWithExactRoles": t.getNodesWithExactRolesHelper(options, &resolvedResult),
+		"hasNodesWithExactRoles": t.hasNodesWithExactRolesHelper(options),
+		"lookup":                 t.lookupHelper(options, &resolvedResult),
+		"base64enc":              base64encode,
+		"base64dec":              base64decode,
+		"b64enc":                 base64encode, // Link the Sprig name to our function
+		"b64dec":                 base64decode, // Link the Sprig name to our function
+		"autoindent":             autoindent,
+		"indent":                 t.indent,
+		"atoi":                   atoi,
+		"toInt":                  toInt,
+		"toBool":                 toBool,
+		"toLiteral":              toLiteral,
+		"fromJSON":               getSprigFunc("fromJson"),      // Link uppercase invocation to JSON parser
+		"mustFromJSON":           getSprigFunc("mustFromJson"),  // Link uppercase invocation to JSON parser
+		"toJSON":                 getSprigFunc("toJson"),        // Link uppercase invocation to JSON parser
+		"mustToJSON":             getSprigFunc("mustToJson"),    // Link uppercase invocation to JSON parser
+		"toRawJSON":              getSprigFunc("toRawJson"),     // Link uppercase invocation to JSON parser
+		"mustToRawJSON":          getSprigFunc("mustToRawJson"), // Link uppercase invocation to JSON parser
+		"fromYAML":               fromYAML,
+		"toYAML":                 toYAML,
+		"fromYaml":               fromYAML, // Link lowercase invocation to YAML parser
+		"toYaml":                 toYAML,   // Link lowercase invocation to YAML parser
+	}
+
+	// Add all the functions from Sprig we will support. If a function name is already
+	// present in the funcMap (for example, when we override Sprig behavior locally),
+	// keep the existing implementation.
+	for fname, f := range sprigFuncMap {
+		if _, exists := funcMap[fname]; exists {
+			continue
+		}
+
+		funcMap[fname] = f
+	}
+
+	if options.EncryptionEnabled {
+		funcMap["fromSecret"] = t.fromSecretProtectedHelper(options, &resolvedResult)
+		funcMap["protect"] = t.protectHelper(options)
+		funcMap["copySecretData"] = t.copySecretDataProtectedHelper(options, &resolvedResult)
+	} else {
+		// In other encryption modes, return a readable error if the protect template function is accidentally used.
+		funcMap["protect"] = func(_ string) (string, error) { return "", ErrProtectNotEnabled }
+	}
+
+	for _, funcName := range t.config.DisabledFunctions {
+		delete(funcMap, funcName)
+	}
+
+	for customFuncName, customFunc := range options.CustomFunctions {
+		funcMap[customFuncName] = customFunc
+	}
+
+	// Wrap any denylisted functions so that using them results in a clear error at
+	// template execution time instead of an undefined function error.
+	if len(options.DenylistFunctions) != 0 {
+		for _, name := range options.DenylistFunctions {
+			funcMap[name] = func(_ ...interface{}) (interface{}, error) {
+				if isSensitiveSprigFunction(name) {
+					return nil, fmt.Errorf(
+						"%w: function '%s' is considered a security risk",
+						ErrDenylistedFunctionUsed,
+						name,
+					)
+				}
+
+				return nil, fmt.Errorf("%w: function '%s' is not allowed", ErrDenylistedFunctionUsed, name)
+			}
+		}
+	}
+
+	// create template processor and Initialize function map
+	tmpl := template.New("tmpl").Delims(t.config.StartDelim, t.config.StopDelim).Funcs(funcMap)
+
+	var templateStr string
+	templateStr = string(tmplRaw)
+
+	klog.V(2).Infof("Initial template str to resolve : %v ", templateStr)
+
+	if options.DecryptionEnabled {
+		templateStr, err = t.processEncryptedStrs(options, &resolvedResult, templateStr)
+		if err != nil {
+			return resolvedResult, err
+		}
+	}
+
+	// processForDataTypes handles scenarios where quotes need to be removed for
+	// special data types or cases where multiple values are returned
+	templateStr = t.processForDataTypes(templateStr)
+
+	// convert `autoindent` placeholders to `indent N`
+	if strings.Contains(templateStr, "autoindent") {
+		templateStr = t.processForAutoIndent(templateStr)
+	}
+
+	tmpl, err = tmpl.Parse(templateStr)
+	if err != nil {
+		tmplRawStr := string(tmplRaw)
+		klog.Errorf(
+			"error parsing template string %v,\n template str %v,\n error: %v", tmplRawStr, templateStr, err,
+		)
+
+		return resolvedResult, fmt.Errorf("failed to parse the template JSON string %v: %w", tmplRawStr, err)
+	}
+
+	var buf bytes.Buffer
+
+	// If the dynamic watcher caching style is disabled, clear the cache after resolving the template.
+	if t.tempCallCache != nil {
+		defer t.tempCallCache.Clear()
+	}
+
+	if t.dynamicWatcher != nil {
+		watcher := *options.Watcher
+
+		if !t.config.SkipBatchManagement {
+			err := t.dynamicWatcher.StartQueryBatch(watcher)
+			if err != nil {
+				if !errors.Is(err, client.ErrQueryBatchInProgress) {
+					return resolvedResult, err
+				}
+
+				return resolvedResult, fmt.Errorf(
+					"ResolveTemplate cannot be called with the same watchedObject in parallel: %w", err,
+				)
+			}
+
+			defer func() {
+				err := t.dynamicWatcher.EndQueryBatch(watcher)
+				if err != nil {
+					klog.Errorf("failed to end the query batch for %s: %v", watcher, err)
+				}
+			}()
+		}
+
+		ctx, err = t.applyContextTransformers(context, options)
+		if err != nil {
+			return resolvedResult, err
+		}
+	}
+
+	err = tmpl.Execute(&buf, ctx)
+	if err != nil {
+		tmplRawStr := string(tmplRaw)
+		klog.Errorf("error resolving the template %v,\n template str %v,\n error: %v", tmplRawStr, templateStr, err)
+
+		return resolvedResult, fmt.Errorf("failed to resolve the template %v: %w", tmplRawStr, err)
+	}
+
+	resolvedTemplateStr := buf.String()
+	klog.V(3).Infof("resolved template str: %v ", resolvedTemplateStr)
+
+	resolvedResult.ResolvedJSON = buf.Bytes()
+
+	return resolvedResult, nil
+}
+
 // ResolveTemplate accepts a map marshaled as JSON or YAML. It also accepts a combination of structs and maps that
 // ultimately end in a string value to be made available when the template is processed.
 // For example, if the argument is `struct{ClusterName string}{"cluster1"}`,


### PR DESCRIPTION
Hi! 

I made a really quick and quite ugly draft on something that I would like template-resolver to support but I am not sure if it is okay with you. The code is just meant to give you a rough idea of the code changes and what I am trying to achieve here. 

We are planning to use Policy using the rendered manifest pattern since it should make it easier to detect problems. The overall plan is to resolve the policy with template-resolver in Git then sync through GitOps. 

At the moment, this looks to be possible, but since we are following this pattern, I would like to extend the functionality of template-resolver to be able to resolve templates that are not YAML. This way we can mix PolicyGenerator with templates better with this pattern:

For example, currently I have this yaml file to create a Policy from PolicyGenerator:

```
object-templates-raw: |
  {{ $versions := fromConfigMap “ns-setings” “operator-settings" "component.gitlab-runner.operator.version" }}
  {{ $channel := fromConfigMap “ns-settings” “operator-settings" "component.gitlab-runner.operator.channel" }}
  {{ if and $versions $channel }}
  {{ $version_list := split "," $versions }}
  - complianceType: mustonlyhave
    objectDefinition:
      apiVersion: policy.open-cluster-management.io/v1beta1
      kind: OperatorPolicy
      metadata:
        name: gitlab-runner-operator
        namespace: ns-settings
      spec:
        complianceType: musthave
        operatorGroup:
          name: gitlab-runner-operator
          namespace: operator-gitlab-runner
        complianceConfig:
          catalogSourceUnhealthy: Compliant
          deploymentsUnavailable: NonCompliant
          deprecationsPresent: Compliant
          upgradesAvailable: Compliant
        remediationAction: enforce
        removalBehavior:
          clusterServiceVersions: Delete
          customResourceDefinitions: Keep
          operatorGroups: DeleteIfUnused
          subscriptions: Delete
        subscription:
          channel: {{ $channel }}
          config:
            resources:
              limits:
                cpu: 300m
                memory: 1.5Gi
              requests:
                memory: 1Gi
          name: gitlab-runner-operator
          namespace: operator-gitlab-runner
          source: certified-operators
          sourceNamespace: openshift-marketplace
          startingCSV: {{ printf "gitlab-runner-operator.v%s" $version_list._0 }}
        upgradeApproval: Automatic
        versions:
  {{ range $v := $version_list }}
          {{ printf "- gitlab-runner-operator.v%s" $v }}
  {{ end }}
  {{ end }}
```


As you can see, doing this with current template-resolver, it is quite ugly and not very readable (but maybe I am missing something cool with the templating engine?). However, if we open the template-resolver to allow non-YAML, we could create a template like this:

```
{{ $versions := fromConfigMap “ns-settings” “operator-settings" "component.gitlab-runner.operator.version" }}
{{ $channel := fromConfigMap “ns-settings” “operator-settings" "component.gitlab-runner.operator.channel" }}
{{- if and $versions $channel -}}
{{- $version_list := split "," $versions }}
apiVersion: policy.open-cluster-management.io/v1beta1
kind: OperatorPolicy
metadata:
  name: gitlab-runner-operator
  namespace: ns-settings
spec:
  complianceType: musthave
  operatorGroup:
    name: gitlab-runner-operator
    namespace: operator-gitlab-runner
  complianceConfig:
    catalogSourceUnhealthy: Compliant
    deploymentsUnavailable: NonCompliant
    deprecationsPresent: Compliant
    upgradesAvailable: Compliant
  remediationAction: enforce
  removalBehavior:
    clusterServiceVersions: Delete
    customResourceDefinitions: Keep
    operatorGroups: DeleteIfUnused
    subscriptions: Delete
  subscription:
    channel: {{ $channel }}
    config:
      resources:
        limits:
          cpu: 300m
          memory: 1.5Gi
        requests:
          memory: 1Gi
    name: gitlab-runner-operator
    namespace: operator-gitlab-runner
    source: certified-operators
    sourceNamespace: openshift-marketplace
    startingCSV: {{ printf "gitlab-runner-operator.v%s" $version_list._0 }}
  upgradeApproval: Automatic
  versions:
  {{ range $v := $version_list }}
          {{ printf "- gitlab-runner-operator.v%s" $v }}
  {{ end }}
  {{ end }}
```

We could then, for example, run template-resolver with —skip-policy-validation and —local-resources to run the template to generate a valid OperatorPolicy YAML. And finally run PolicyGenerator to create the Policy resource. 

Nevertheless, I am not sure if this is something you would be interested? For our OpenShift clusters, it would be incredibly useful and help solve a lot of our pains. 